### PR TITLE
fix: add exponential backoff + jitter for Groq 429 rate limits

### DIFF
--- a/src/app/api/agents/dispatch/route.ts
+++ b/src/app/api/agents/dispatch/route.ts
@@ -6,20 +6,35 @@ import { getFilePrompt } from "@/lib/prompts";
 import { canSendOutreach } from "@/lib/resend";
 
 // Retry wrapper for transient LLM API failures (429, 5xx, network errors)
-async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 2): Promise<Response> {
+// Uses exponential backoff + jitter for 429 rate limits, faster retry for other transients
+async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3): Promise<Response> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const res = await fetch(url, options);
       if (res.ok || [400, 401, 403, 404].includes(res.status)) return res;
+
       if (attempt < maxRetries) {
-        const delay = attempt === 0 ? 1000 : 3000;
+        let delay: number;
+
+        if (res.status === 429) {
+          // Rate limit: exponential backoff with jitter (2^attempt * 1000ms + random 0-500ms)
+          const baseDelay = Math.pow(2, attempt) * 1000;
+          const jitter = Math.random() * 500;
+          delay = baseDelay + jitter;
+          console.log(`Rate limit (429), retrying in ${Math.round(delay)}ms (attempt ${attempt + 1}/${maxRetries + 1})`);
+        } else {
+          // Other transient errors: shorter exponential backoff
+          delay = Math.pow(1.5, attempt) * 500 + Math.random() * 200;
+        }
+
         await new Promise(r => setTimeout(r, delay));
         continue;
       }
       return res;
     } catch (err) {
       if (attempt === maxRetries) throw err;
-      const delay = attempt === 0 ? 1000 : 3000;
+      // Network errors: moderate backoff with jitter
+      const delay = Math.pow(1.5, attempt) * 800 + Math.random() * 300;
       await new Promise(r => setTimeout(r, delay));
     }
   }

--- a/src/app/api/cron/sentinel/route.ts
+++ b/src/app/api/cron/sentinel/route.ts
@@ -1174,10 +1174,17 @@ export async function GET(req: Request) {
     dispatches.push({ type: "brain", target: "ceo_review", payload: { company: slug } });
   }
 
-  // 5. Unverified deploys → Ops worker
-  for (const r of unverifiedDeploys) {
+  // 5. Unverified deploys → Ops worker (staggered to prevent Groq 429s)
+  for (let i = 0; i < unverifiedDeploys.length; i++) {
+    const r = unverifiedDeploys[i];
     await dispatchToWorker("ops", r.slug, "sentinel_unverified_deploy");
     dispatches.push({ type: "worker", target: "health_check", payload: { company: r.slug } });
+
+    // Stagger subsequent dispatches by 200-800ms to prevent concurrent Groq hits
+    if (i < unverifiedDeploys.length - 1) {
+      const staggerDelay = 200 + Math.random() * 600;
+      await new Promise(resolve => setTimeout(resolve, staggerDelay));
+    }
   }
 
   // 6. Evolve due → Evolver brain


### PR DESCRIPTION
## Summary

Fixes concurrent Ops dispatches hitting Groq 429 rate limits (P1 backlog item).

### Changes Made

**1. Enhanced `fetchWithRetry` with proper exponential backoff:**
- 429 rate limits: exponential backoff (2^attempt * 1000ms) + jitter (0-500ms)
- Other transient errors: moderate backoff (1.5^attempt * 500ms) + jitter
- Network errors: moderate backoff with jitter
- Increased max retries from 2 to 3 for better resilience

**2. Added staggered Ops dispatches in Sentinel:**
- Added 200-800ms random delays between concurrent Ops worker dispatches
- Prevents thundering herd when multiple companies need health checks

### Problem Solved

Previously, when Sentinel detected multiple unverified deploys, it would dispatch Ops workers for all companies simultaneously. This caused:
- All requests hitting Groq API at the exact same time
- Groq free tier rate limits (6,000 RPD) being exceeded
- Cascading failures when retries also happened simultaneously

### Technical Details

**Rate Limit Backoff Formula:**
- First retry: 2^0 * 1000ms + random(0-500ms) = ~1-1.5s
- Second retry: 2^1 * 1000ms + random(0-500ms) = ~2-2.5s  
- Third retry: 2^2 * 1000ms + random(0-500ms) = ~4-4.5s

**Staggering Logic:**
- Only applies to Ops dispatches (primary Groq users)
- Random 200-800ms delays prevent synchronized bursts
- Growth/Outreach still dispatch immediately (they use Gemini primary)

### Risk Assessment

**Medium Risk:** This changes core orchestration retry logic and could affect all LLM API calls.

**Mitigation:** 
- Only affects transient failure scenarios (429, 5xx, network errors)
- Success path unchanged (immediate return on 2xx)
- Backwards compatible (existing behavior for 4xx client errors)
- Build verified successfully

### Test Plan

- [ ] Monitor Groq API error rates in agent_actions after deployment
- [ ] Verify Ops dispatches are still processed (just staggered)
- [ ] Check that other worker agents (Growth/Outreach) are unaffected
- [ ] Validate backoff timing under load (look for ~1s, ~2s, ~4s retry intervals)

🤖 Generated as Hive self-improvement from backlog task 02456d05-6980-4fab-a389-090596ee3b82