### PR TITLE
Auto-merge PRs with low risk scores

### DIFF
--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -148,6 +148,45 @@ export async function POST(req: Request) {
       break;
     }
 
+    case "pull_request": {
+      // Auto-trigger CEO review when PRs are opened
+      if (body.action !== "opened") break;
+
+      const repoName = body.repository?.name;
+      const prNumber = body.pull_request?.number;
+      if (!repoName || !prNumber) break;
+
+      // Skip hive repo (self-improvement PRs are handled differently)
+      if (repoName === "hive") break;
+
+      // Check if this is a company repo
+      const [company] = await sql`SELECT slug FROM companies WHERE slug = ${repoName}`;
+      if (!company) break;
+
+      // Dispatch CEO review event
+      await dispatchEvent("ceo_review", {
+        source: "github_webhook",
+        company: company.slug,
+        pr_number: prNumber,
+        trigger: "pr_opened"
+      });
+
+      // Log the PR for tracking
+      await sql`
+        INSERT INTO agent_actions (company_id, agent, action_type, description, status, started_at, finished_at)
+        VALUES (
+          (SELECT id FROM companies WHERE slug = ${company.slug}),
+          'webhook',
+          'pr_opened',
+          ${`PR #${prNumber} opened, dispatching CEO review`},
+          'success',
+          now(),
+          now()
+        )
+      `;
+      break;
+    }
+
     case "issues": {
       // Detect new hive-directive issues created directly on GitHub
       if (body.action !== "opened") break;


### PR DESCRIPTION
## Problem
Stale PRs accumulate because nobody merges them. The CEO agent already calculates risk scores and has auto-merge logic for scores 0-3, but PRs weren't being automatically reviewed when opened.

## Solution  
Added `pull_request` event handler to GitHub webhook that:
- Triggers `ceo_review` when PRs are opened on company repos
- Skips hive repo (self-improvement PRs handled separately) 
- Logs PR events for tracking

## Implementation
- Added pull_request case to `/api/webhooks/github/route.ts`
- Dispatches `ceo_review` event with company and pr_number
- CEO agent's existing auto-merge logic (score 0-3) now activates automatically

## Testing
- ✅ Build passes without errors
- ✅ Webhook code compiles correctly
- ✅ Follows existing event dispatch patterns

This completes the auto-merge flow: Engineer opens PR → webhook triggers CEO review → CEO auto-merges if score 0-3.

🤖 Generated with Hive self-improvement