### PR TITLE
feat: implement context API caching to reduce duplicate queries

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -449,3 +449,19 @@ CREATE TABLE routing_weights (
 CREATE INDEX idx_routing_weights_task_model ON routing_weights(task_type, model);
 CREATE INDEX idx_routing_weights_agent ON routing_weights(agent);
 CREATE INDEX idx_routing_weights_success_rate ON routing_weights(success_rate);
+
+-- Context cache: cache agent context responses to reduce duplicate DB queries
+-- Unlogged table for performance (data lost on crash, but cache can be rebuilt)
+CREATE UNLOGGED TABLE context_cache (
+  cache_key     TEXT PRIMARY KEY,           -- format: "company_id:agent_type:cycle_id"
+  agent_type    TEXT NOT NULL CHECK (agent_type IN ('build', 'growth', 'fix')),
+  company_id    TEXT NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  cycle_id      TEXT REFERENCES cycles(id) ON DELETE CASCADE,
+  context_data  JSONB NOT NULL,             -- cached context response
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at    TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '10 minutes')
+);
+
+CREATE INDEX idx_context_cache_expires ON context_cache(expires_at);
+CREATE INDEX idx_context_cache_company ON context_cache(company_id);
+CREATE INDEX idx_context_cache_cycle ON context_cache(cycle_id);

--- a/src/app/api/agents/context/route.ts
+++ b/src/app/api/agents/context/route.ts
@@ -5,6 +5,7 @@ import { computeValidationScore, normalizeBusinessType } from "@/lib/validation"
 import { getCapabilitySummary } from "@/lib/hive-capabilities";
 import { checkForbidden } from "@/lib/phase-gate";
 import { normalizeError, errorSimilarity } from "@/lib/error-normalize";
+import { getCachedContext, setCachedContext, type AgentType } from "@/lib/cache";
 
 // GET /api/agents/context?agent=build|growth|fix&company_slug=X
 export async function GET(req: NextRequest) {
@@ -19,6 +20,10 @@ export async function GET(req: NextRequest) {
     return err("Missing agent or company_slug query params", 400);
   }
 
+  if (!['build', 'growth', 'fix'].includes(agent)) {
+    return err(`Unknown agent type: ${agent}`, 400);
+  }
+
   const sql = getDb();
 
   const [company] = await sql`
@@ -30,15 +35,38 @@ export async function GET(req: NextRequest) {
     return json({});
   }
 
-  if (agent === "build") {
-    return json(await buildContext(sql, company));
-  } else if (agent === "growth") {
-    return json(await growthContext(sql, company));
-  } else if (agent === "fix") {
-    return json(await fixContext(sql, company));
+  // Get the current running cycle ID for cache key
+  const [currentCycle] = await sql`
+    SELECT id FROM cycles
+    WHERE company_id = ${company.id} AND status = 'running'
+    ORDER BY started_at DESC LIMIT 1
+  `.catch(() => []);
+
+  const cycleId = currentCycle?.id || null;
+  const agentType = agent as AgentType;
+
+  // Try cache first
+  const cached = await getCachedContext(company.id, agentType, cycleId);
+  if (cached) {
+    return json(cached);
   }
 
-  return err(`Unknown agent type: ${agent}`, 400);
+  // Cache miss - compute context from DB
+  let contextData;
+  if (agent === "build") {
+    contextData = await buildContext(sql, company);
+  } else if (agent === "growth") {
+    contextData = await growthContext(sql, company);
+  } else if (agent === "fix") {
+    contextData = await fixContext(sql, company);
+  } else {
+    return err(`Unknown agent type: ${agent}`, 400);
+  }
+
+  // Store in cache for future requests
+  await setCachedContext(company.id, agentType, contextData, cycleId);
+
+  return json(contextData);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/api/cycles/[id]/route.ts
+++ b/src/app/api/cycles/[id]/route.ts
@@ -1,5 +1,6 @@
 import { getDb, json, err } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
+import { invalidateCycleCache, invalidateCompanyCache } from "@/lib/cache";
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAuth();
@@ -19,5 +20,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     RETURNING *
   `;
   if (!cycle) return err("Cycle not found", 404);
+
+  // Invalidate context cache since cycle data changed
+  await Promise.all([
+    invalidateCycleCache(id),
+    invalidateCompanyCache(cycle.company_id)
+  ]);
+
   return json(cycle);
 }

--- a/src/app/api/dispatch/cycle-complete/route.ts
+++ b/src/app/api/dispatch/cycle-complete/route.ts
@@ -1,5 +1,6 @@
 import { getDb, json } from "@/lib/db";
 import { getSettingValue } from "@/lib/settings";
+import { invalidateCompanyCache } from "@/lib/cache";
 
 const REPO = "carloshmiranda/hive";
 const HIVE_URL = process.env.NEXT_PUBLIC_URL || "https://hive-phi.vercel.app";
@@ -75,13 +76,21 @@ export async function POST(req: Request) {
 
   // Log the completion
   if (agent && company) {
-    await sql`
-      INSERT INTO agent_actions (agent, action_type, status, description, started_at, finished_at, company_id)
-      SELECT ${agent}, ${action_type || "cycle_callback"}, 'success',
-        ${`Chain callback: ${agent} completed ${status || "unknown"} for ${company}`},
-        NOW(), NOW(),
-        (SELECT id FROM companies WHERE slug = ${company} LIMIT 1)
-    `.catch(() => {});
+    const [companyRecord] = await sql`
+      SELECT id FROM companies WHERE slug = ${company} LIMIT 1
+    `.catch(() => []);
+
+    if (companyRecord) {
+      await sql`
+        INSERT INTO agent_actions (agent, action_type, status, description, started_at, finished_at, company_id)
+        VALUES (${agent}, ${action_type || "cycle_callback"}, 'success',
+          ${`Chain callback: ${agent} completed ${status || "unknown"} for ${company}`},
+          NOW(), NOW(), ${companyRecord.id})
+      `.catch(() => {});
+
+      // Invalidate cache for the completed company since cycle state changed
+      await invalidateCompanyCache(companyRecord.id);
+    }
   }
 
   // Step 1: Health gate check

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,115 @@
+import { getDb } from "./db";
+
+export type AgentType = 'build' | 'growth' | 'fix';
+
+/**
+ * Generate cache key for agent context
+ * Format: company_id:agent_type:cycle_id
+ */
+export function generateCacheKey(companyId: string, agentType: AgentType, cycleId?: string): string {
+  return `${companyId}:${agentType}:${cycleId || 'no-cycle'}`;
+}
+
+/**
+ * Get cached context for an agent
+ */
+export async function getCachedContext(companyId: string, agentType: AgentType, cycleId?: string): Promise<unknown | null> {
+  const sql = getDb();
+  const cacheKey = generateCacheKey(companyId, agentType, cycleId);
+
+  try {
+    // Clean expired entries and get valid cache
+    const [cached] = await sql`
+      DELETE FROM context_cache WHERE expires_at < now();
+
+      SELECT context_data FROM context_cache
+      WHERE cache_key = ${cacheKey} AND expires_at > now()
+      LIMIT 1
+    `.catch(() => []);
+
+    if (cached) {
+      return cached.context_data;
+    }
+
+    return null;
+  } catch (error) {
+    console.warn('Cache get failed:', error);
+    return null; // Fail gracefully - don't block on cache errors
+  }
+}
+
+/**
+ * Store context in cache with 10-minute TTL
+ */
+export async function setCachedContext(
+  companyId: string,
+  agentType: AgentType,
+  contextData: unknown,
+  cycleId?: string
+): Promise<void> {
+  const sql = getDb();
+  const cacheKey = generateCacheKey(companyId, agentType, cycleId);
+
+  try {
+    await sql`
+      INSERT INTO context_cache (cache_key, agent_type, company_id, cycle_id, context_data)
+      VALUES (${cacheKey}, ${agentType}, ${companyId}, ${cycleId || null}, ${JSON.stringify(contextData)})
+      ON CONFLICT (cache_key) DO UPDATE SET
+        context_data = ${JSON.stringify(contextData)},
+        created_at = now(),
+        expires_at = now() + INTERVAL '10 minutes'
+    `.catch(() => {}); // Ignore cache write failures - don't block normal flow
+  } catch (error) {
+    console.warn('Cache set failed:', error);
+    // Don't throw - cache failures shouldn't break the API
+  }
+}
+
+/**
+ * Invalidate cache for a specific company (called when cycle updates)
+ */
+export async function invalidateCompanyCache(companyId: string): Promise<void> {
+  const sql = getDb();
+
+  try {
+    await sql`
+      DELETE FROM context_cache WHERE company_id = ${companyId}
+    `.catch(() => {});
+  } catch (error) {
+    console.warn('Cache invalidation failed:', error);
+  }
+}
+
+/**
+ * Invalidate cache for a specific cycle (called when cycle data changes)
+ */
+export async function invalidateCycleCache(cycleId: string): Promise<void> {
+  const sql = getDb();
+
+  try {
+    await sql`
+      DELETE FROM context_cache WHERE cycle_id = ${cycleId}
+    `.catch(() => {});
+  } catch (error) {
+    console.warn('Cache invalidation failed:', error);
+  }
+}
+
+/**
+ * Clean up expired cache entries (can be called periodically)
+ */
+export async function cleanExpiredCache(): Promise<number> {
+  const sql = getDb();
+
+  try {
+    const result = await sql`
+      DELETE FROM context_cache WHERE expires_at < now()
+      RETURNING cache_key
+    `.catch(() => []);
+
+    return result.length;
+  } catch (error) {
+    console.warn('Cache cleanup failed:', error);
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements caching layer for `/api/agents/context` to eliminate duplicate DB queries during agent dispatch
- Addresses backlog item: reduce 10+ repeated queries when same company dispatched twice in one cycle
- Expected performance: 50%+ reduction in context queries, 75%+ cache hit rate within cycles

## Technical Implementation

- **Context cache table**: Unlogged Postgres table with 10-min TTL, cache keys format `company_id:agent_type:cycle_id`
- **Cache logic**: Check cache first → DB queries on miss → store response with TTL
- **Invalidation**: Clear cache on cycle updates (`/api/cycles/[id]`) and cycle completions (`/api/dispatch/cycle-complete`)
- **Graceful degradation**: Cache failures don't block normal API flow

## Test Plan

- [x] `npx next build` passes
- [ ] Cache hit rate >75% within a cycle (to be measured in production)
- [ ] Context API queries reduced by 50% (to be measured in production)  
- [ ] Cache TTL correctly set to 10 minutes
- [ ] Manual test: multiple context calls for same company return cached data
- [ ] Manual test: cycle update invalidates relevant cache entries

## Files Changed

- `schema.sql`: Added `context_cache` unlogged table
- `src/lib/cache.ts`: New cache operations library  
- `src/app/api/agents/context/route.ts`: Added cache check/store logic
- `src/app/api/cycles/[id]/route.ts`: Added cache invalidation on update
- `src/app/api/dispatch/cycle-complete/route.ts`: Added cache invalidation on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)