### PR TITLE
fix: reduce backlog cascade dispatch failures from 95% to P0-only

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -365,7 +365,8 @@ export async function POST(req: Request) {
   // Fetch ready backlog items
   // Cooldown: items with recent attempt failures wait 30min before retry.
   // Uses dispatched_at (reset on failure) as proxy for "last attempt time".
-  // When called from chain (completed_id present), filter to P0/P1 only
+  // When called from chain (completed_id present), only auto-dispatch P0 items
+  // This prevents cascade waste on lower-priority items that can wait for regular dispatch
   const isChainDispatch = !!completed_id;
   let backlogItems: any[];
   try {
@@ -383,7 +384,7 @@ export async function POST(req: Request) {
         )
         AND (array_length(regexp_match(notes, '\\[attempt \\d+\\]'), 1) IS NULL
              OR (SELECT count(*) FROM regexp_matches(notes, '\\[attempt \\d+\\]', 'g')) < 5)
-        AND priority IN ('P0', 'P1')
+        AND priority = 'P0'
         ORDER BY
           CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 ELSE 3 END,
           created_at ASC

--- a/src/app/api/backlog/route.ts
+++ b/src/app/api/backlog/route.ts
@@ -1,5 +1,6 @@
 import { getDb, json, err } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
+import { getSettingValue } from "@/lib/settings";
 
 // GET /api/backlog — list Hive self-improvement backlog items
 export async function GET(req: Request) {
@@ -76,4 +77,124 @@ export async function POST(req: Request) {
   `;
 
   return json(item, 201);
+}
+
+// PATCH /api/backlog — dispatch a specific backlog item or next ready item to hive-engineer.yml
+export async function PATCH(req: Request) {
+  const session = await requireAuth();
+  if (!session) return err("Unauthorized", 401);
+
+  const { searchParams } = new URL(req.url);
+  const itemId = searchParams.get("id"); // specific item to dispatch
+  const action = searchParams.get("action"); // "dispatch"
+
+  if (action !== "dispatch") {
+    return err("action=dispatch is required");
+  }
+
+  const sql = getDb();
+  let targetItem;
+
+  if (itemId) {
+    // Dispatch specific item
+    const [item] = await sql`
+      SELECT * FROM hive_backlog
+      WHERE id = ${itemId} AND status IN ('ready', 'approved')
+      LIMIT 1
+    `;
+    targetItem = item;
+  } else {
+    // Dispatch next ready item (all priorities)
+    const [item] = await sql`
+      SELECT * FROM hive_backlog
+      WHERE status IN ('ready', 'approved')
+      AND NOT (
+        notes ILIKE '%[attempt %]%'
+        AND dispatched_at IS NOT NULL
+        AND dispatched_at > NOW() - INTERVAL '30 minutes'
+      )
+      ORDER BY
+        CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 ELSE 3 END,
+        created_at ASC
+      LIMIT 1
+    `;
+    targetItem = item;
+  }
+
+  if (!targetItem) {
+    return err("No dispatchable item found");
+  }
+
+  // Get GitHub token for dispatch
+  const ghToken = await getSettingValue("github_token").catch(() => null);
+  if (!ghToken) {
+    return err("GitHub token not configured");
+  }
+
+  // Check for previous failures and add context
+  const attemptMatch = (targetItem.notes || "").match(/\[attempt \d+\]/g);
+  const attemptCount = attemptMatch?.length || 0;
+  let taskDescription = targetItem.description;
+
+  if (attemptCount > 0) {
+    const failures = await sql`
+      SELECT error, description, finished_at
+      FROM agent_actions
+      WHERE agent = 'engineer' AND status = 'failed'
+      AND company_id IS NULL
+      AND finished_at > NOW() - INTERVAL '7 days'
+      AND (description ILIKE ${"%" + targetItem.title.slice(0, 30) + "%"}
+           OR output::text ILIKE ${"%" + (targetItem.id || "") + "%"})
+      ORDER BY finished_at DESC
+      LIMIT 3
+    `.catch(() => []);
+
+    if (failures.length > 0) {
+      const previousErrors = failures
+        .map((f, i) => `Attempt ${i + 1}: ${(f.error || f.description || "unknown error").slice(0, 300)}`)
+        .join("\n");
+      taskDescription += `\n\n⚠️ PREVIOUS ATTEMPTS FAILED (attempt ${attemptCount + 1}):\n${previousErrors}\n\nDo NOT repeat the same approach. Analyze why it failed and try a different strategy.`;
+    }
+  }
+
+  // Dispatch to GitHub Actions
+  const res = await fetch("https://api.github.com/repos/carloshmiranda/hive/dispatches", {
+    method: "POST",
+    headers: { Authorization: `token ${ghToken}`, Accept: "application/vnd.github.v3+json" },
+    body: JSON.stringify({
+      event_type: "feature_request",
+      client_payload: {
+        source: "manual_dispatch",
+        company: "_hive",
+        task: taskDescription,
+        backlog_id: targetItem.id,
+        priority: targetItem.priority,
+        attempt: attemptCount + 1,
+        chain_next: false, // Manual dispatch - don't auto-chain
+        spec: targetItem.spec || undefined,
+      },
+    }),
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (res.ok || res.status === 204) {
+    // Mark as dispatched
+    await sql`
+      UPDATE hive_backlog
+      SET status = 'dispatched', dispatched_at = NOW()
+      WHERE id = ${targetItem.id}
+    `.catch(() => {});
+
+    return json({
+      dispatched: true,
+      item: {
+        id: targetItem.id,
+        title: targetItem.title,
+        priority: targetItem.priority,
+        attempt: attemptCount + 1
+      }
+    });
+  }
+
+  return err("GitHub dispatch failed", res.status);
 }


### PR DESCRIPTION
## Problem
Backlog cascade dispatch had 95% failure rate (156/164 dispatches wasted in 7 days) because chain dispatch was filtering to P0/P1 items but most backlog items are P2.

## Solution
**Step 1**: Modified cascade auto-dispatch to only handle P0 items (truly critical/urgent)
- Changed `AND priority IN ('P0', 'P1')` to `AND priority = 'P0'` in chain dispatch
- Prevents cascade waste on lower-priority items that can wait for regular dispatch

**Step 2**: Added manual dispatch capability for all priority levels
- New `PATCH /api/backlog?action=dispatch` endpoint
- Supports dispatching specific item by ID or next ready item
- Maintains error context and attempt tracking
- Uses same GitHub Actions dispatch mechanism as cascade

## Impact
- Reduces cascade dispatch failures by only auto-dispatching truly urgent P0 items
- Preserves ability to dispatch P1/P2 items via manual/dashboard trigger
- Maintains error learning and attempt context across dispatch methods
- Keeps existing PR auto-merge and decomposition logic intact

## Testing
- `npx next build` passes
- All acceptance criteria met