### PR TITLE
feat: add PR tracking data to chain callbacks and agent profiles

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
 
   const sql = getDb();
   const body = await req.json().catch(() => ({}));
-  const { completed_id, completed_status } = body;
+  const { completed_id, completed_status, pr_number, branch, changed_files } = body;
 
   // Periodic cleanup of expired cooldown entries
   cleanupFailedItemsCache();
@@ -66,12 +66,43 @@ export async function POST(req: Request) {
     if (completed_status === "success") {
       // Engineer "success" means PR created, NOT code merged.
       // Move to 'pr_open' so it stays visible until PR is merged.
+      let prInfo = '';
+      if (pr_number && branch) {
+        const fileCount = changed_files ? (Array.isArray(changed_files) ? changed_files.length : 0) : 0;
+        prInfo = ` PR #${pr_number} on ${branch} (${fileCount} files) created via chain dispatch — awaiting merge.`;
+      } else {
+        prInfo = ' PR created via chain dispatch — awaiting merge.';
+      }
+
       await sql`
         UPDATE hive_backlog
         SET status = 'pr_open', dispatched_at = NOW(),
-            notes = COALESCE(notes, '') || ' PR created via chain dispatch — awaiting merge.'
+            notes = COALESCE(notes, '') || ${prInfo}
         WHERE id = ${completed_id} AND status IN ('dispatched', 'in_progress')
       `.catch(() => {});
+
+      // Store PR tracking data in the agent_actions record
+      if (pr_number && branch) {
+        await sql`
+          UPDATE agent_actions
+          SET output = CASE
+            WHEN output IS NULL THEN
+              ${JSON.stringify({ pr_number, branch, changed_files })}
+            ELSE
+              jsonb_set(
+                COALESCE(output, '{}'),
+                '{pr_tracking}',
+                ${JSON.stringify({ pr_number, branch, changed_files })}
+              )
+          END
+          WHERE agent = 'engineer'
+          AND action_type = 'feature_request'
+          AND status = 'success'
+          AND company_id IS NULL
+          AND started_at > NOW() - INTERVAL '1 hour'
+          AND (output::text ILIKE ${'%' + completed_id + '%'} OR description ILIKE ${'%' + completed_id + '%'})
+        `.catch(() => {});
+      }
 
     } else {
       // Failed: learn from it. Track attempts, decompose if too big.

--- a/src/lib/agent-profiles.ts
+++ b/src/lib/agent-profiles.ts
@@ -19,6 +19,7 @@ type AgentProfile = {
   by_company: Record<string, { success_rate: number }>;
   strengths: string[];
   weaknesses: string[];
+  recent_prs: Array<{ pr_number: number; branch: string; changed_files?: string[]; finished_at: string }>;
 };
 
 export type AgentProfilesResult = {
@@ -40,6 +41,7 @@ export async function getAgentProfiles(): Promise<AgentProfilesResult> {
       aa.status,
       aa.error,
       aa.company_id,
+      aa.output,
       c.slug,
       EXTRACT(EPOCH FROM (aa.finished_at - aa.started_at))::int as duration_s,
       aa.finished_at
@@ -175,6 +177,30 @@ export async function getAgentProfiles(): Promise<AgentProfilesResult> {
       else if (stats.success_rate < 0.5) weaknesses.push(at);
     }
 
+    // Extract recent PRs from successful actions
+    const recent_prs: Array<{ pr_number: number; branch: string; changed_files?: string[]; finished_at: string }> = [];
+    for (const a of agentActions) {
+      if (a.status === "success" && a.output) {
+        try {
+          const output = typeof a.output === 'string' ? JSON.parse(a.output) : a.output;
+          const prTracking = output?.pr_tracking;
+          if (prTracking && prTracking.pr_number && prTracking.branch) {
+            recent_prs.push({
+              pr_number: Number(prTracking.pr_number),
+              branch: String(prTracking.branch),
+              changed_files: Array.isArray(prTracking.changed_files) ? prTracking.changed_files : undefined,
+              finished_at: a.finished_at
+            });
+          }
+        } catch {
+          // Ignore JSON parse errors
+        }
+      }
+    }
+    // Sort by most recent first and limit to 10
+    recent_prs.sort((a, b) => new Date(b.finished_at).getTime() - new Date(a.finished_at).getTime());
+    recent_prs.splice(10);
+
     profiles[agent] = {
       overall_success_rate: Math.round(overallRate * 100) / 100,
       trend,
@@ -183,6 +209,7 @@ export async function getAgentProfiles(): Promise<AgentProfilesResult> {
       by_company: companyStats,
       strengths,
       weaknesses,
+      recent_prs,
     };
 
     // Generate recommendations


### PR DESCRIPTION
## Summary
This enhancement enables the chain callback mechanism to track PR creation outcomes across the system.

### Changes Made
- **Backlog dispatch route**: Now accepts , , and  in chain callback payload
- **PR status tracking**: Enhanced notes with detailed PR information (number, branch, file count)  
- **Agent actions integration**: Store PR tracking data in  field for successful Engineer actions
- **Agent profiles enhancement**: Extended to include  array with PR metadata from last 30 days

### Implementation Details
- Modified  to extract and process PR tracking data from callbacks
- Updated  to include recent PR data in agent performance profiles
- All PR tracking data is stored as JSON in the  field of  table

### Testing
- ✅    ▲ Next.js 15.5.13

   Creating an optimized production build ...
 ✓ Compiled successfully in 3.5s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/50) ...
   Generating static pages (12/50) 
   Generating static pages (24/50) 
   Generating static pages (37/50) 
 ✓ Generating static pages (50/50)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                    9.74 kB         118 kB
├ ○ /_not-found                            998 B         103 kB
├ ƒ /api/actions                           284 B         102 kB
├ ƒ /api/admin/scout-reset                 284 B         102 kB
├ ƒ /api/agents/analytics                  284 B         102 kB
├ ƒ /api/agents/backfill-errors            284 B         102 kB
├ ƒ /api/agents/companies                  284 B         102 kB
├ ƒ /api/agents/consolidate                284 B         102 kB
├ ƒ /api/agents/context                    284 B         102 kB
├ ƒ /api/agents/costs                      284 B         102 kB
├ ƒ /api/agents/dispatch                   284 B         102 kB
├ ƒ /api/agents/error-patterns             284 B         102 kB
├ ƒ /api/agents/extract                    284 B         102 kB
├ ƒ /api/agents/log                        284 B         102 kB
├ ƒ /api/agents/performance                284 B         102 kB
├ ƒ /api/agents/playbook                   284 B         102 kB
├ ƒ /api/agents/profiles                   284 B         102 kB
├ ƒ /api/agents/provision                  284 B         102 kB
├ ƒ /api/agents/repair-infra               284 B         102 kB
├ ƒ /api/agents/research-type              284 B         102 kB
├ ƒ /api/agents/stripe/product             284 B         102 kB
├ ƒ /api/agents/tasks/[id]                 284 B         102 kB
├ ƒ /api/agents/token                      284 B         102 kB
├ ƒ /api/agents/validate-drift             284 B         102 kB
├ ƒ /api/agents/visibility                 284 B         102 kB
├ ƒ /api/approvals                         284 B         102 kB
├ ƒ /api/approvals/[id]/decide             284 B         102 kB
├ ƒ /api/approvals/batch                   284 B         102 kB
├ ƒ /api/approvals/scout-cleanup           284 B         102 kB
├ ƒ /api/auth/[...nextauth]                284 B         102 kB
├ ƒ /api/backlog                           284 B         102 kB
├ ƒ /api/backlog/[id]                      284 B         102 kB
├ ƒ /api/backlog/dispatch                  284 B         102 kB
├ ƒ /api/companies                         284 B         102 kB
├ ƒ /api/companies/[id]                    284 B         102 kB
├ ƒ /api/companies/[id]/assess             284 B         102 kB
├ ƒ /api/companies/[id]/domain             284 B         102 kB
├ ƒ /api/cron/digest                       284 B         102 kB
├ ƒ /api/cron/metrics                      284 B         102 kB
├ ƒ /api/cron/sentinel                     284 B         102 kB
├ ƒ /api/cycles                            284 B         102 kB
├ ƒ /api/cycles/[id]                       284 B         102 kB
├ ƒ /api/cycles/[id]/cleanup               284 B         102 kB
├ ƒ /api/cycles/[id]/review                284 B         102 kB
├ ƒ /api/dashboard                         284 B         102 kB
├ ƒ /api/directives                        284 B         102 kB
├ ƒ /api/directives/[id]/close             284 B         102 kB
├ ƒ /api/dispatch/cycle-complete           284 B         102 kB
├ ƒ /api/dispatch/health-gate              284 B         102 kB
├ ƒ /api/evolver                           284 B         102 kB
├ ƒ /api/health                            284 B         102 kB
├ ƒ /api/imports                           284 B         102 kB
├ ƒ /api/metrics                           284 B         102 kB
├ ƒ /api/notify                            284 B         102 kB
├ ƒ /api/playbook                          284 B         102 kB
├ ƒ /api/portfolio                         284 B         102 kB
├ ƒ /api/research                          284 B         102 kB
├ ƒ /api/settings                          284 B         102 kB
├ ƒ /api/social                            284 B         102 kB
├ ƒ /api/tasks                             284 B         102 kB
├ ƒ /api/tasks/[id]                        284 B         102 kB
├ ƒ /api/todos                             284 B         102 kB
├ ƒ /api/webhooks/github                   284 B         102 kB
├ ƒ /api/webhooks/stripe                   284 B         102 kB
├ ƒ /api/webhooks/telegram                 284 B         102 kB
├ ƒ /company/[slug]                      5.82 kB         111 kB
├ ○ /login                               1.23 kB         107 kB
└ ○ /settings                            3.32 kB         109 kB
+ First Load JS shared by all             102 kB
  ├ chunks/1255-1d98a9a4b8a18d10.js        46 kB
  ├ chunks/4bd1b696-f785427dddbba9fb.js  54.2 kB
  └ other shared chunks (total)          1.93 kB


ƒ Middleware                             87.6 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand passes successfully
- No breaking changes to existing APIs
- Backward compatible - missing PR data gracefully handled

This addresses the requirement to record PR number, branch, and changed files in chain callbacks for better visibility into Engineer agent outcomes.