### PR TITLE
feat: evolver proposal pipeline cleanup

### DIFF
--- a/src/app/api/cycles/[id]/review/route.ts
+++ b/src/app/api/cycles/[id]/review/route.ts
@@ -2,6 +2,71 @@ import { getDb, json, err } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
+// Deduplicate CEO PR review proposals - keep most recent, reject older ones
+async function deduplicateCeoPrReviewProposals(sql: any) {
+  // Find all pending CEO review proposals
+  const ceoReviewProposals = await sql`
+    SELECT id, title, created_at
+    FROM evolver_proposals
+    WHERE status = 'pending'
+      AND gap_type = 'outcome'
+      AND (title ILIKE '%CEO%' AND title ILIKE '%review%')
+    ORDER BY created_at DESC
+  `;
+
+  if (ceoReviewProposals.length <= 1) {
+    return; // No duplicates to handle
+  }
+
+  // Group similar proposals (those with overlapping keywords)
+  const groups: Array<typeof ceoReviewProposals> = [];
+  const processed = new Set<string>();
+
+  for (const proposal of ceoReviewProposals) {
+    if (processed.has(proposal.id)) continue;
+
+    const group = [proposal];
+    processed.add(proposal.id);
+
+    // Find similar proposals (simple keyword overlap approach)
+    const keyWords = proposal.title.toLowerCase().split(/\s+/).filter((w: string) => w.length > 3);
+
+    for (const other of ceoReviewProposals) {
+      if (processed.has(other.id)) continue;
+
+      const otherWords = other.title.toLowerCase().split(/\s+/).filter((w: string) => w.length > 3);
+      const overlap = keyWords.filter((w: string) => otherWords.includes(w)).length;
+
+      // If significant overlap (>30% of words), consider them duplicates
+      if (overlap >= Math.ceil(Math.min(keyWords.length, otherWords.length) * 0.3)) {
+        group.push(other);
+        processed.add(other.id);
+      }
+    }
+
+    if (group.length > 1) {
+      groups.push(group);
+    }
+  }
+
+  // For each group, keep the most recent and reject older ones
+  for (const group of groups) {
+    group.sort((a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+    const [keep, ...reject] = group;
+
+    if (reject.length > 0) {
+      const rejectIds = reject.map((p: any) => p.id);
+      await sql`
+        UPDATE evolver_proposals
+        SET status = 'rejected',
+            reviewed_at = NOW(),
+            notes = ${`Deduplicated: keeping most recent proposal ${keep.id} (${keep.title})`}
+        WHERE id = ANY(${rejectIds})
+      `;
+    }
+  }
+}
+
 // PATCH /api/cycles/[id]/review
 // Updates cycle with CEO review data (agent-authorized endpoint)
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -66,6 +131,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     if (!cycle) {
       return err("Cycle not found", 404);
     }
+
+    // Deduplicate CEO PR review proposals - keep most recent, reject older ones
+    await deduplicateCeoPrReviewProposals(sql);
 
     return json({
       ok: true,

--- a/src/app/api/evolver/route.ts
+++ b/src/app/api/evolver/route.ts
@@ -2,6 +2,44 @@ import { getDb, json, err } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { dispatchEvent } from "@/lib/dispatch";
 
+// Batch reject proposals based on criteria
+async function batchRejectProposals(criteria: any, notes?: string) {
+  const sql = getDb();
+
+  if (criteria.title_patterns && Array.isArray(criteria.title_patterns)) {
+    // Handle recurring-escalation-automation patterns
+    const patterns = criteria.title_patterns;
+    const proposals = await sql`
+      SELECT id, title FROM evolver_proposals
+      WHERE status = 'pending'
+      AND (
+        title ILIKE ANY(${patterns.map((p: string) => `%${p}%`)})
+        ${criteria.gap_type ? sql`AND gap_type = ${criteria.gap_type}` : sql``}
+      )
+    `;
+
+    if (proposals.length === 0) {
+      return json({ rejected_count: 0, message: "No proposals matched criteria" });
+    }
+
+    const proposalIds = proposals.map(p => p.id);
+    const rejectionNote = notes || "Batch rejected: describes symptoms rather than root causes";
+
+    await sql`
+      UPDATE evolver_proposals
+      SET status = 'rejected', reviewed_at = NOW(), notes = ${rejectionNote}
+      WHERE id = ANY(${proposalIds})
+    `;
+
+    return json({
+      rejected_count: proposals.length,
+      rejected_proposals: proposals.map(p => ({ id: p.id, title: p.title }))
+    });
+  }
+
+  return err("No valid criteria provided for batch rejection");
+}
+
 // GET /api/evolver          → list proposals (default: pending)
 // GET /api/evolver?status=all → all proposals
 export async function GET(req: Request) {
@@ -36,13 +74,21 @@ export async function GET(req: Request) {
   return json(proposals);
 }
 
-// PATCH /api/evolver — approve/reject/defer a proposal
+// PATCH /api/evolver — approve/reject/defer a proposal or batch reject
 export async function PATCH(req: Request) {
   const session = await requireAuth();
   if (!session) return err("Unauthorized", 401);
 
   const body = await req.json();
-  const { id, decision, notes } = body;
+  const { id, decision, notes, batch_action, criteria } = body;
+
+  // Handle batch operations
+  if (batch_action) {
+    if (batch_action === "batch_reject" && criteria) {
+      return await batchRejectProposals(criteria, notes);
+    }
+    return err("Invalid batch action or missing criteria");
+  }
 
   if (!id || !decision) return err("id and decision required");
   if (!["approved", "rejected", "deferred"].includes(decision)) {
@@ -132,5 +178,67 @@ export async function PATCH(req: Request) {
   }
 
   return json({ ok: true, status: decision });
+}
+
+// POST /api/evolver/auto-approve — auto-approve proposals after 48h
+export async function POST(req: Request) {
+  // This endpoint should only be called by system/cron, not by users
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return err("Unauthorized", 401);
+  }
+
+  const sql = getDb();
+
+  // Auto-approve capability gaps with medium severity + concrete fix after 48h
+  const autoApproveProposals = await sql`
+    SELECT id, title, proposed_fix, affected_companies
+    FROM evolver_proposals
+    WHERE status = 'pending'
+      AND gap_type = 'capability'
+      AND severity = 'medium'
+      AND proposed_fix->>'change' IS NOT NULL
+      AND LENGTH(proposed_fix->>'change') > 50
+      AND created_at < NOW() - INTERVAL '48 hours'
+  `;
+
+  let approvedCount = 0;
+
+  for (const proposal of autoApproveProposals) {
+    // Auto-approve the proposal
+    await sql`
+      UPDATE evolver_proposals
+      SET status = 'approved',
+          reviewed_at = NOW(),
+          notes = 'Auto-approved after 48h: capability gap with medium severity and concrete fix'
+      WHERE id = ${proposal.id}
+    `;
+
+    // Handle the implementation based on fix type
+    const fixType = proposal.proposed_fix?.type;
+
+    if (fixType === "setup_action") {
+      const affectedCompanies = proposal.affected_companies || [];
+      const firstCompany = affectedCompanies[0];
+      let companyId = null;
+      if (firstCompany) {
+        const [comp] = await sql`SELECT id FROM companies WHERE slug = ${firstCompany} LIMIT 1`;
+        companyId = comp?.id || null;
+      }
+      await sql`
+        INSERT INTO agent_actions (agent, action_type, description, status, output, started_at, finished_at, company_id)
+        VALUES ('evolver', 'setup_action', ${`Auto-approved evolver proposal: ${proposal.title}`}, 'pending_manual',
+          ${JSON.stringify({ proposal_id: proposal.id, proposed_fix: proposal.proposed_fix, auto_approved: true })}::jsonb,
+          NOW(), NOW(), ${companyId})
+      `;
+    }
+
+    approvedCount++;
+  }
+
+  return json({
+    auto_approved_count: approvedCount,
+    auto_approved_proposals: autoApproveProposals.map(p => ({ id: p.id, title: p.title }))
+  });
 }
 


### PR DESCRIPTION
**Source:** Evolver proposal 9a62a6bb-17a8-476e-b637-aa9a43a27dbc

## Changes

This PR implements three key fixes to reduce the evolver proposal pending queue by ~60%:

1. **Batch-reject functionality**: Added  PATCH endpoint support for batch operations to reject recurring-escalation-automation proposals that describe symptoms rather than root causes.

2. **CEO PR review deduplication**: Added logic in  to automatically deduplicate similar CEO review proposals, keeping the most recent and rejecting older duplicates.

3. **Auto-approve after 48h**: Added  POST endpoint to auto-approve capability gaps with medium severity and concrete fixes after 48 hours.

## Expected Impact
- Reduce pending proposal count from 33 to ~12 actionable items
- Make remaining proposals reviewable in one 10-minute session
- Improve signal-to-noise ratio in evolver proposals

## Testing
- ✅    ▲ Next.js 15.5.13

   Creating an optimized production build ...
 ✓ Compiled successfully in 3.6s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/52) ...
   Generating static pages (13/52) 
   Generating static pages (26/52) 
   Generating static pages (39/52) 
 ✓ Generating static pages (52/52)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /                                    9.74 kB         118 kB
├ ○ /_not-found                            998 B         103 kB
├ ƒ /api/actions                           294 B         102 kB
├ ƒ /api/admin/scout-reset                 294 B         102 kB
├ ƒ /api/agents/analytics                  294 B         102 kB
├ ƒ /api/agents/backfill-errors            294 B         102 kB
├ ƒ /api/agents/companies                  294 B         102 kB
├ ƒ /api/agents/consolidate                294 B         102 kB
├ ƒ /api/agents/context                    294 B         102 kB
├ ƒ /api/agents/costs                      294 B         102 kB
├ ƒ /api/agents/dispatch                   294 B         102 kB
├ ƒ /api/agents/error-patterns             294 B         102 kB
├ ƒ /api/agents/extract                    294 B         102 kB
├ ƒ /api/agents/fix-validation-system      294 B         102 kB
├ ƒ /api/agents/log                        294 B         102 kB
├ ƒ /api/agents/migrate-stats              294 B         102 kB
├ ƒ /api/agents/performance                294 B         102 kB
├ ƒ /api/agents/playbook                   294 B         102 kB
├ ƒ /api/agents/profiles                   294 B         102 kB
├ ƒ /api/agents/provision                  294 B         102 kB
├ ƒ /api/agents/repair-infra               294 B         102 kB
├ ƒ /api/agents/research-type              294 B         102 kB
├ ƒ /api/agents/stripe/product             294 B         102 kB
├ ƒ /api/agents/tasks/[id]                 294 B         102 kB
├ ƒ /api/agents/token                      294 B         102 kB
├ ƒ /api/agents/validate-drift             294 B         102 kB
├ ƒ /api/agents/visibility                 294 B         102 kB
├ ƒ /api/approvals                         294 B         102 kB
├ ƒ /api/approvals/[id]/decide             294 B         102 kB
├ ƒ /api/approvals/batch                   294 B         102 kB
├ ƒ /api/approvals/scout-cleanup           294 B         102 kB
├ ƒ /api/auth/[...nextauth]                294 B         102 kB
├ ƒ /api/backlog                           294 B         102 kB
├ ƒ /api/backlog/[id]                      294 B         102 kB
├ ƒ /api/backlog/dispatch                  294 B         102 kB
├ ƒ /api/companies                         294 B         102 kB
├ ƒ /api/companies/[id]                    294 B         102 kB
├ ƒ /api/companies/[id]/assess             294 B         102 kB
├ ƒ /api/companies/[id]/domain             294 B         102 kB
├ ƒ /api/cron/company-health               294 B         102 kB
├ ƒ /api/cron/digest                       294 B         102 kB
├ ƒ /api/cron/metrics                      294 B         102 kB
├ ƒ /api/cron/sentinel                     294 B         102 kB
├ ƒ /api/cycles                            294 B         102 kB
├ ƒ /api/cycles/[id]                       294 B         102 kB
├ ƒ /api/cycles/[id]/cleanup               294 B         102 kB
├ ƒ /api/cycles/[id]/review                294 B         102 kB
├ ƒ /api/dashboard                         294 B         102 kB
├ ƒ /api/directives                        294 B         102 kB
├ ƒ /api/directives/[id]/close             294 B         102 kB
├ ƒ /api/dispatch/cycle-complete           294 B         102 kB
├ ƒ /api/dispatch/health-gate              294 B         102 kB
├ ƒ /api/evolver                           294 B         102 kB
├ ƒ /api/health                            294 B         102 kB
├ ƒ /api/imports                           294 B         102 kB
├ ƒ /api/metrics                           294 B         102 kB
├ ƒ /api/notify                            294 B         102 kB
├ ƒ /api/playbook                          294 B         102 kB
├ ƒ /api/portfolio                         294 B         102 kB
├ ƒ /api/research                          294 B         102 kB
├ ƒ /api/roadmap/progress                  294 B         102 kB
├ ƒ /api/settings                          294 B         102 kB
├ ƒ /api/setup/qstash-schedules            294 B         102 kB
├ ƒ /api/social                            294 B         102 kB
├ ƒ /api/tasks                             294 B         102 kB
├ ƒ /api/tasks/[id]                        294 B         102 kB
├ ƒ /api/todos                             294 B         102 kB
├ ƒ /api/webhooks/github                   294 B         102 kB
├ ƒ /api/webhooks/stripe                   294 B         102 kB
├ ƒ /api/webhooks/telegram                 294 B         102 kB
├ ƒ /company/[slug]                      5.82 kB         111 kB
├ ○ /login                               1.23 kB         107 kB
└ ○ /settings                            3.32 kB         109 kB
+ First Load JS shared by all             102 kB
  ├ chunks/1255-1d98a9a4b8a18d10.js        46 kB
  ├ chunks/4bd1b696-f785427dddbba9fb.js  54.2 kB
  └ other shared chunks (total)          1.93 kB


ƒ Middleware                             87.6 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand passes
- All TypeScript errors resolved
- API endpoints follow existing patterns

**Risk level:** Medium (modifies core evolver pipeline logic)
**Files modified:** 2 (evolver route, cycle review route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)