### PR TITLE
fix: wire riskScore into PR merge decision gate

### DIFF
--- a/src/lib/pr-risk-scoring.ts
+++ b/src/lib/pr-risk-scoring.ts
@@ -179,9 +179,7 @@ export async function analyzePR(
   // Ensure minimum score of 0
   riskScore = Math.max(0, riskScore);
 
-  // Decision logic — cost-only escalation model
-  // Carlos only reviews changes that impact operational costs.
-  // All quality-risk PRs auto-merge if CI passes (safety gates block, not score).
+  // Decision logic
   let decision: PRAnalysis['decision'];
   if (!hardGatesPassed) {
     // Safety gates failed (secrets, conflicts, CI, destructive SQL, huge diff) — block
@@ -189,8 +187,11 @@ export async function analyzePR(
   } else if (costImpact) {
     // Cost-impacting changes always need Carlos's review
     decision = 'escalate';
+  } else if (riskScore >= 5) {
+    // High risk score (5+) — too many compounding risk factors, escalate for review
+    decision = 'escalate';
   } else {
-    // CI passed + no safety issues + no cost impact → auto-merge regardless of score
+    // CI passed + no safety issues + no cost impact + low risk → auto-merge
     decision = 'auto_merge';
   }
 


### PR DESCRIPTION
## Summary

- `riskScore` was computed from multiple weighted factors (schema changes, security patterns, large diffs, new API routes, design violations) but the decision block only checked `hardGatesPassed` and `costImpact` — making `riskScore` entirely inert
- Add `riskScore >= 5 → escalate` as the third gate, so high-risk PRs are held for review rather than silently auto-merging

## Test plan

- [ ] Confirm a PR that previously would score ≥5 but pass hard gates now gets `decision = 'escalate'`
- [ ] Confirm low-risk PRs (score < 5, no cost impact, CI green) still get `decision = 'auto_merge'`
- [ ] Run `npx tsc --noEmit` — no type errors

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)