### PR TITLE
fix: add GitHub Issue routing rules to agent prompts

### DIFF
--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -859,6 +859,13 @@ jobs:
                `GH_TOKEN="$GH_PAT" gh pr merge --auto --squash --delete-branch <PR_NUMBER>`
             7. Log to agent_actions
 
+            ## GitHub Issue routing
+            When creating a GitHub Issue, route to the correct repo:
+            - Company product work (features, bugs for a specific company) → `carloshmiranda/{company-slug}`
+            - Hive platform work (infra bugs, agent improvements, orchestrator issues) → `carloshmiranda/hive`
+            Always use: `GH_TOKEN="$GH_PAT" gh issue create --repo carloshmiranda/{correct-repo} ...`
+            Never file company issues in the hive repo or vice versa.
+
             ## Rules
             - Always use `GH_TOKEN="$GH_PAT"` for gh commands
             - Write to agent_actions table: what you did, status, any errors

--- a/prompts/ceo.md
+++ b/prompts/ceo.md
@@ -524,6 +524,14 @@ curl -X POST "https://hive-phi.vercel.app/api/decisions" \
 
 This creates a decision track record that improves strategic quality over time through retrospective analysis.
 
+## GitHub Issue routing
+
+When creating a GitHub Issue for escalations or blockers:
+- **Product/feature work for this company** → `carloshmiranda/{{COMPANY_SLUG}}`
+- **Hive platform issues** (orchestrator bugs, agent failures, infra problems) → `carloshmiranda/hive`
+
+Always use: `GH_TOKEN="$GH_PAT" gh issue create --repo carloshmiranda/{{COMPANY_SLUG}} ...`
+
 ## Rules
 - Never spend money without an approval gate (anything >€20 needs Carlos's OK).
 - Never change the product's core value proposition without a directive from Carlos.

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -310,6 +310,16 @@ If QA tests don't exist or can't run for a company:
 }
 ```
 
+## GitHub Issue routing
+
+When creating a GitHub Issue, route to the correct repo:
+- **Company product work** (features, bugs, improvements for {{COMPANY_NAME}}) → `carloshmiranda/{{COMPANY_SLUG}}`
+- **Hive platform work** (infra bugs, agent fixes, orchestrator improvements) → `carloshmiranda/hive`
+
+Always use: `GH_TOKEN="$GH_PAT" gh issue create --repo carloshmiranda/{{COMPANY_SLUG}} ...`
+
+Never file company issues in the `hive` repo or vice versa.
+
 ## Rules
 - Max 2 tasks per cycle. Quality over quantity.
 - Never modify payment logic (Stripe webhooks, checkout) without an explicit directive.

--- a/prompts/healer.md
+++ b/prompts/healer.md
@@ -89,6 +89,16 @@ This validates ALL queries against the schema map and catches cascading mismatch
 4. **Agent dispatch failures** — nightly cycle can't execute
 5. **Individual agent errors** — specific tasks failing
 
+## GitHub Issue routing
+
+When creating a GitHub Issue, route to the correct repo:
+- **Systemic Hive errors** (same bug across multiple companies, orchestrator/API/schema bugs) → `carloshmiranda/hive`
+- **Company-specific errors** (bug only in one company's code) → `carloshmiranda/{company-slug}`
+
+Always use: `GH_TOKEN="$GH_PAT" gh issue create --repo carloshmiranda/{correct-repo} ...`
+
+Never file company-specific issues in the `hive` repo.
+
 ## Rules
 - **Fix, don't refactor.** Change the minimum to address the error.
 - **Never delete functionality.** Make it work, not disappear.


### PR DESCRIPTION
## Summary

- CEO, Engineer, and Healer prompts now include an explicit **GitHub Issue routing** section
- `hive-engineer.yml` workflow prompt also gets the same routing rule
- Rule: company product work → `carloshmiranda/{company-slug}`, Hive platform work → `carloshmiranda/hive`

## Why

Fixes the MISTAKES.md entry from 2026-04-01 where `hive-orchestrator` was filing company-specific escalation issues in the `carloshmiranda/hive` repo. Without explicit routing instructions, agents default to whatever repo they're currently checked out in.

## Test plan
- [ ] Build passes (verified locally)
- [ ] CEO prompt `## GitHub Issue routing` section present
- [ ] Engineer prompt `## GitHub Issue routing` section present  
- [ ] Healer prompt `## GitHub Issue routing` section present
- [ ] `hive-engineer.yml` `## GitHub Issue routing` section present

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)