### PR TITLE
feat: wire skill catalog into Engineer prompt and workflow

### DIFF
--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -859,6 +859,12 @@ jobs:
                `GH_TOKEN="$GH_PAT" gh pr merge --auto --squash --delete-branch <PR_NUMBER>`
             7. Log to agent_actions
 
+            ## Skill catalog
+            Before writing frontend code, configuring Tailwind, or deploying, read the relevant skill:
+            - Tailwind CSS: `cat .claude/skills/tailwind-4-docs/SKILL.md`
+            - React/Next.js components: `cat .claude/skills/vercel-react-best-practices/SKILL.md`
+            - Deploying to Vercel: `cat .claude/skills/deploy-to-vercel/SKILL.md`
+
             ## GitHub Issue routing
             When creating a GitHub Issue, route to the correct repo:
             - Company product work (features, bugs for a specific company) → `carloshmiranda/{company-slug}`

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -52,6 +52,18 @@ Report which playbook entries you consulted:
 ]
 ```
 
+## Skill Catalog
+
+Before writing frontend code, configuring styling, or triggering deployments, read the relevant skill reference files from the Hive repo:
+
+| When to use | Skill file |
+|------------|------------|
+| Writing or reviewing any Tailwind CSS | `.claude/skills/tailwind-4-docs/SKILL.md` — Tailwind v4 utilities, variants, config, migration from v3 |
+| Writing React components, Next.js pages, data fetching | `.claude/skills/vercel-react-best-practices/SKILL.md` — 65 performance rules from Vercel Engineering |
+| Deploying to Vercel, creating preview deployments | `.claude/skills/deploy-to-vercel/SKILL.md` — deployment actions and Vercel CLI steps |
+
+These skills are checked into the Hive repo (not the company repo). Read them with `cat /path/to/hive/.claude/skills/<skill>/SKILL.md` when working in the company context.
+
 ## How you work
 
 ### File Scope Enforcement (CRITICAL)


### PR DESCRIPTION
## Summary

- Engineer prompt now has a `## Skill Catalog` section referencing 3 installed skills
- `hive-engineer.yml` workflow prompt includes the same skill catalog guidance
- Skills referenced: `tailwind-4-docs`, `vercel-react-best-practices`, `deploy-to-vercel`

## Why

Engineer was building without consulting the installed Tailwind v4 docs, React best practices, and Vercel deployment skills. This wires them in so they're consulted at the right time — before writing frontend code or triggering deployments.

## Test plan
- [ ] Build passes
- [ ] `prompts/engineer.md` has `## Skill Catalog` section
- [ ] `hive-engineer.yml` has `## Skill catalog` section
- [ ] Skill paths match actual `.claude/skills/` directory structure

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)