### PR TITLE
fix: minimum cycle duration gate — prevent premature cycle chaining

### DIFF
--- a/src/app/api/dispatch/cycle-complete/route.ts
+++ b/src/app/api/dispatch/cycle-complete/route.ts
@@ -117,6 +117,42 @@ export async function POST(req: Request) {
     }
   }
 
+  // Minimum cycle duration gate: CEO completing planning does not mean the cycle is done.
+  // If CEO just called us and no non-CEO agent has succeeded yet, the cycle has barely started.
+  // Schedule a retry in 2h so Engineer/Growth have time to run before we chain to the next company.
+  if (agent === "ceo" && company && company !== "_retry") {
+    const [companyGateRec] = await sql`
+      SELECT id FROM companies WHERE slug = ${company} LIMIT 1
+    `.catch((e: any) => { console.warn(`[cycle-complete] gate company lookup failed: ${e?.message || e}`); return []; });
+
+    if (companyGateRec) {
+      const [activeCycle] = await sql`
+        SELECT id, started_at FROM cycles
+        WHERE company_id = ${companyGateRec.id} AND status = 'running'
+        ORDER BY started_at DESC LIMIT 1
+      `.catch((e: any) => { console.warn(`[cycle-complete] gate cycle lookup failed: ${e?.message || e}`); return []; });
+
+      if (activeCycle) {
+        const cycleAgeHours = (Date.now() - new Date(activeCycle.started_at).getTime()) / 3_600_000;
+        if (cycleAgeHours < 4) {
+          const [nonCeoSuccess] = await sql`
+            SELECT id FROM agent_actions
+            WHERE company_id = ${companyGateRec.id}
+            AND agent NOT IN ('ceo', 'dispatch', 'sentinel', 'ops')
+            AND status = 'success'
+            AND started_at > ${activeCycle.started_at}
+            LIMIT 1
+          `.catch((e: any) => { console.warn(`[cycle-complete] gate non-ceo check failed: ${e?.message || e}`); return [null]; });
+
+          if (!nonCeoSuccess) {
+            await scheduleChainRetry("minimum_cycle_duration_not_met", 2 * 60 * 60);
+            return json({ chained: false, reason: "minimum_cycle_duration_not_met", chain_retry: true, company });
+          }
+        }
+      }
+    }
+  }
+
   // Step 1: Health gate check
   const healthRes = await fetch(`${HIVE_URL}/api/dispatch/health-gate`, {
     method: "POST",


### PR DESCRIPTION
## Problem

CEO planning is not the end of a cycle. When CEO calls `/api/dispatch/cycle-complete` immediately after writing its plan, the route was chaining to the **next company cycle** before Engineer or Growth had run any work. This caused 3+ consecutive cycles with identical `started_at` timestamps per company (no real work done).

Reported in issues #298, #302, #303.

## Root cause

`cycle-complete/route.ts` had no minimum duration check. The existing 6-hour `daysSinceLastCycle < 0.25` guard only prevents re-dispatching the **same company** — it doesn't prevent premature chaining immediately after CEO planning.

## Fix

Added a minimum cycle duration gate **before the health gate check**:

1. If the calling agent is `ceo` and the company's current cycle is under 4 hours old...
2. Query `agent_actions` for any non-CEO agent with `status = 'success'` since cycle start
3. If none found → schedule QStash retry in 2h, return `{ reason: "minimum_cycle_duration_not_met" }`
4. Engineer/Growth have their 2h window; if they complete first they call `cycle-complete` themselves and bypass this gate (they're not `ceo`)

## Test plan
- [ ] Build passes (verified locally)
- [ ] CI passes
- [ ] Verify `reason: "minimum_cycle_duration_not_met"` appears in logs when CEO completes before Engineer runs
- [ ] Verify normal chaining still works once a non-CEO agent has a success action

Closes #298
Closes #302
Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)