### PR TITLE
fix: increase spec gen timeout + retry with fallback model (#239)

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -397,7 +397,7 @@ export async function POST(req: Request) {
   }
 
   const body = await req.json().catch(() => ({}));
-  let { completed_id, completed_status, pr_number, branch, changed_files } = body;
+  let { completed_id, completed_status, pr_number, branch, changed_files, force_respec } = body;
 
   // Handle structured status codes from Engineer callbacks (ADR-032)
   const { status_code, concerns, context_needed, blocking_issue } = body;
@@ -1811,13 +1811,29 @@ export async function POST(req: Request) {
 
     // Permanently blocked — skip and ensure blocked status
     // Exception: if [manual_spec] is present in notes OR spec field is now populated — allow dispatch
+    // Exception: if force_respec=true — strip the block tag and allow a fresh spec attempt
     if (notes.includes("[manual_spec_needed]") && !hasManualSpecInNotes && !hasSpec) {
-      await sql`
-        UPDATE hive_backlog
-        SET status = 'blocked', dispatched_at = NULL
-        WHERE id = ${candidate.id} AND status IN ('ready', 'approved', 'planning')
-      `.catch(() => {});
-      continue;
+      if (force_respec) {
+        // Strip [manual_spec_needed] and [no_spec] tags so spec generation runs fresh
+        const cleanedNotes = notes
+          .replace(/\[manual_spec_needed\][^\n]*/g, "")
+          .replace(/\[no_spec\]/g, "")
+          .trim();
+        await sql`
+          UPDATE hive_backlog
+          SET notes = ${cleanedNotes || null}, status = 'ready', dispatched_at = NULL
+          WHERE id = ${candidate.id}
+        `.catch(() => {});
+        candidate.notes = cleanedNotes || null;
+        // Fall through — treat as specless candidate for fresh spec generation
+      } else {
+        await sql`
+          UPDATE hive_backlog
+          SET status = 'blocked', dispatched_at = NULL
+          WHERE id = ${candidate.id} AND status IN ('ready', 'approved', 'planning')
+        `.catch(() => {});
+        continue;
+      }
     }
 
     // Specless item that already failed once — block permanently

--- a/src/lib/backlog-planner.ts
+++ b/src/lib/backlog-planner.ts
@@ -634,11 +634,19 @@ The response will be automatically parsed as structured JSON.`;
 
   try {
     const responseFormat = getResponseFormat("backlog-planner");
-    const response = await callLLM("planner", prompt, {
+    let response = await callLLM("planner", prompt, {
       maxTokens: 2048,
       temperature: 0.3,
-      timeout: 25000,
+      timeout: 45000,
       responseFormat,
+    }).catch(async (firstErr: any) => {
+      // Retry once with a faster model (no structured format — parse raw JSON)
+      console.warn("[backlog-planner] First spec attempt failed, retrying with fallback model:", firstErr?.message || firstErr);
+      return callLLM("ops", prompt, {
+        maxTokens: 2048,
+        temperature: 0.3,
+        timeout: 30000,
+      });
     });
 
     // Parse the structured JSON response directly
@@ -784,7 +792,14 @@ Respond with ONLY valid JSON (no markdown):
     const response = await callLLM("planner", prompt, {
       maxTokens: 1500,
       temperature: 0.3,
-      timeout: 20000,
+      timeout: 30000,
+    }).catch(async (firstErr: any) => {
+      console.warn("[backlog-planner] Company task spec first attempt failed, retrying:", firstErr?.message || firstErr);
+      return callLLM("ops", prompt, {
+        maxTokens: 1500,
+        temperature: 0.3,
+        timeout: 20000,
+      });
     });
 
     let jsonStr = response.content.trim();


### PR DESCRIPTION
## Summary

- `generateSpec()`: timeout 25s → 45s; on failure, retries once with `ops` model chain (faster models) instead of immediately tagging `[no_spec]`
- `generateCompanyTaskSpec()`: timeout 20s → 30s; same retry pattern
- Dispatch route: `force_respec=true` body param strips `[manual_spec_needed]` and `[no_spec]` tags, allowing a fresh spec generation attempt on permanently-blocked items

## Why

Items were being permanently blocked as `[manual_spec_needed]` after a single transient LLM timeout. The 25s window was too tight for complex items on congested providers. The retry uses `ops` (smaller/faster models) as a fallback so spec gen succeeds even when larger models time out.

## Test plan

- [ ] Build passes (`npx next build`)
- [ ] A backlog item with `[manual_spec_needed]` notes can be unblocked by POSTing `force_respec: true` to `/api/backlog/dispatch`
- [ ] Monitor dispatch logs: should see fewer `[no_spec]` tags after deploy

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)