### PR TITLE
fix: migrate failed item cooldown from in-memory Map to Redis TTL (#214)

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -753,7 +753,7 @@ export async function POST(req: Request) {
       // max_turns = immediate decompose (1 attempt) — retrying same item with same turn budget fails identically
       const maxAttempts = isMaxTurns ? 1 : 3;
       if (item && attempt < maxAttempts && !continued) {
-        trackFailedBacklogItem(item.id, attempt);
+        await trackFailedBacklogItem(item.id, attempt);
       }
 
       // On max_turns failure: LLM-assisted decompose if complexity is M or L
@@ -2293,7 +2293,7 @@ export async function POST(req: Request) {
     }
 
     // Reset cooldown for successfully dispatched item
-    resetBacklogItemCooldown(topItem.id);
+    await resetBacklogItemCooldown(topItem.id);
     syncIssueForBacklog(sql, topItem.id, "dispatched");
 
     // Log successful dispatch

--- a/src/lib/backlog-planner.ts
+++ b/src/lib/backlog-planner.ts
@@ -1,7 +1,7 @@
 import { callLLM } from "@/lib/llm";
 import { getResponseFormat, AGENT_SCHEMAS } from "@/lib/agent-schemas";
 import { getSettingValue } from "@/lib/settings";
-import { isBacklogItemInCooldown, cleanupFailedItemsCache } from "@/lib/dispatch";
+import { isBacklogItemInCooldown } from "@/lib/dispatch";
 
 export interface BacklogSpec {
   acceptance_criteria: string[];
@@ -224,15 +224,17 @@ export async function flagProblemStatementsAsNeedingDecomposition(
 }
 
 /**
- * Filter backlog items to exclude those in cooldown period
- * Also performs cleanup of expired cooldown entries
+ * Filter backlog items to exclude those in cooldown period.
+ * Redis TTL handles expiry — no manual cleanup needed.
  */
-export function filterBacklogItemsByCooldown(items: BacklogItem[]): BacklogItem[] {
-  // Clean up expired entries first
-  cleanupFailedItemsCache();
-
-  // Filter out items that are in cooldown
-  return items.filter(item => !isBacklogItemInCooldown(item.id));
+export async function filterBacklogItemsByCooldown(items: BacklogItem[]): Promise<BacklogItem[]> {
+  const results = await Promise.all(
+    items.map(async (item) => ({
+      item,
+      inCooldown: await isBacklogItemInCooldown(item.id),
+    }))
+  );
+  return results.filter((r) => !r.inCooldown).map((r) => r.item);
 }
 
 /**

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -1,88 +1,51 @@
 import { getGitHubToken } from "./github-app";
+import { cacheGet, cacheSet, cacheDel } from "./redis-cache";
 
-interface FailedBacklogItem {
-  id: string;
-  failedAt: number;
-  cooldownHours: number;
-  attemptCount: number;
-}
-
-// In-memory cache for failed backlog items (2h cooldown by default)
-const failedItemsCache = new Map<string, FailedBacklogItem>();
 const COOLDOWN_HOURS = 2;
-const MAX_CACHE_SIZE = 1000;
+const COOLDOWN_TTL_SECONDS = COOLDOWN_HOURS * 60 * 60;
 
-/**
- * Track a backlog item as recently failed with cooldown period
- */
-export function trackFailedBacklogItem(itemId: string, attemptCount: number = 1): void {
-  const now = Date.now();
-  failedItemsCache.set(itemId, {
-    id: itemId,
-    failedAt: now,
-    cooldownHours: COOLDOWN_HOURS,
-    attemptCount,
-  });
-
-  // Cleanup if cache gets too large
-  if (failedItemsCache.size > MAX_CACHE_SIZE) {
-    cleanupFailedItemsCache();
-  }
+function cooldownKey(itemId: string): string {
+  return `fail:${itemId}`;
 }
 
 /**
- * Check if a backlog item is in cooldown period
+ * Track a backlog item as recently failed with cooldown period.
+ * Stored in Redis with TTL — survives Vercel redeploys.
+ * Falls back to no-op if Redis is unavailable.
  */
-export function isBacklogItemInCooldown(itemId: string): boolean {
-  const failedItem = failedItemsCache.get(itemId);
-  if (!failedItem) return false;
-
-  const now = Date.now();
-  const cooldownMs = failedItem.cooldownHours * 60 * 60 * 1000;
-  return (now - failedItem.failedAt) < cooldownMs;
+export async function trackFailedBacklogItem(itemId: string, attemptCount: number = 1): Promise<void> {
+  await cacheSet(cooldownKey(itemId), { attemptCount, failedAt: Date.now() }, COOLDOWN_TTL_SECONDS);
 }
 
 /**
- * Reset cooldown for a successfully dispatched backlog item
+ * Check if a backlog item is in cooldown period.
+ * Returns false (allow dispatch) if Redis is unavailable.
  */
-export function resetBacklogItemCooldown(itemId: string): void {
-  failedItemsCache.delete(itemId);
+export async function isBacklogItemInCooldown(itemId: string): Promise<boolean> {
+  const entry = await cacheGet<{ attemptCount: number; failedAt: number }>(cooldownKey(itemId));
+  return entry !== null;
 }
 
 /**
- * Get failed items that are still in cooldown
+ * Reset cooldown for a successfully dispatched backlog item.
  */
-export function getFailedItemsInCooldown(): string[] {
-  const now = Date.now();
-  const inCooldown: string[] = [];
-
-  for (const [itemId, failedItem] of failedItemsCache.entries()) {
-    const cooldownMs = failedItem.cooldownHours * 60 * 60 * 1000;
-    if ((now - failedItem.failedAt) < cooldownMs) {
-      inCooldown.push(itemId);
-    }
-  }
-
-  return inCooldown;
+export async function resetBacklogItemCooldown(itemId: string): Promise<void> {
+  await cacheDel(cooldownKey(itemId));
 }
 
 /**
- * Periodically clean up expired entries from failed items cache
+ * @deprecated No-op — TTL-based Redis expiry handles cleanup automatically.
  */
 export function cleanupFailedItemsCache(): void {
-  const now = Date.now();
-  const expiredIds: string[] = [];
+  // Redis TTL handles expiry — nothing to do
+}
 
-  for (const [itemId, failedItem] of failedItemsCache.entries()) {
-    const cooldownMs = failedItem.cooldownHours * 60 * 60 * 1000;
-    if ((now - failedItem.failedAt) >= cooldownMs) {
-      expiredIds.push(itemId);
-    }
-  }
-
-  for (const id of expiredIds) {
-    failedItemsCache.delete(id);
-  }
+/**
+ * @deprecated Returns empty array — Redis doesn't support scanning all keys efficiently on free tier.
+ * Use the dispatch route's per-item cooldown check instead.
+ */
+export async function getFailedItemsInCooldown(): Promise<string[]> {
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `dispatch.ts`: in-memory `Map<string, FailedBacklogItem>` replaced with Redis keys `fail:{itemId}` with 2h TTL via `cacheSet`/`cacheGet`/`cacheDel`
- All cooldown functions are now async
- `filterBacklogItemsByCooldown` in backlog-planner is now async, uses `Promise.all` for parallel checks
- Manual cache cleanup removed — Redis TTL handles expiry automatically

## Why

The in-memory Map was wiped on every Vercel redeploy, causing recently-failed items to skip their cooldown and be immediately re-dispatched. This burned turn budget on items that just failed.

Redis (Upstash free tier) persists across invocations. `cacheSet/cacheGet` already fall back gracefully when Redis is unavailable — so this is safe even during Redis outages (will allow dispatch, not block it).

## Test plan

- [ ] Build passes
- [ ] After a failed dispatch, `GET /api/health` or Redis inspect shows `fail:{item_id}` key with TTL ~7200s
- [ ] Item is not re-dispatched until 2h TTL expires

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)