### PR TITLE
fix: use in_progress for continuation dispatches to prevent stale cleanup reset

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -628,10 +628,12 @@ export async function POST(req: Request) {
 
       console.log(`[backlog] Partial completion for "${completed_id}" — ${turnsUsed}/${maxTurns} turns, continuing with ${continuationTurns}. Last commit: ${lastCommit}`);
 
-      // Mark as in_progress (not failed) — this is a continuation, not a retry
+      // Mark as in_progress (not failed) — this is a continuation, not a retry.
+      // Use in_progress (not dispatched) so the 30-min stale dispatch cleanup doesn't
+      // reset this item while the continuation is still running.
       await sql`
         UPDATE hive_backlog
-        SET status = 'dispatched', dispatched_at = NOW(),
+        SET status = 'in_progress', dispatched_at = NOW(),
             notes = COALESCE(notes, '') || ${` [partial] Graceful exit at ${turnsUsed}/${maxTurns} turns — progress preserved${branchName ? ` on ${branchName}` : ''}. Last: ${lastCommit.slice(0, 80)}. Continuing with ${continuationTurns} turns.`}
         WHERE id = ${completed_id} AND status IN ('dispatched', 'in_progress')
       `.catch((e: any) => { console.warn(`[backlog] mark ${completed_id} as partial failed: ${e?.message || e}`); });
@@ -675,6 +677,21 @@ export async function POST(req: Request) {
 
             if (contRes.ok || contRes.status === 204) {
               console.log(`[backlog] Continuation dispatched for "${item.title}" with ${continuationTurns} turns`);
+              // Create an agent_actions record so the engineer_busy gate blocks concurrent
+              // dispatches during the continuation. Without this, the gate sees no running
+              // record and allows a second item to be dispatched in parallel.
+              const [contAction] = await sql`
+                INSERT INTO agent_actions (agent, action_type, status, description, started_at)
+                VALUES ('engineer', 'feature_request', 'running',
+                  ${`Continuation: "${item.title}" (${item.priority}, ${continuationTurns} turns)`},
+                  NOW())
+                RETURNING id
+              `.catch(() => [{ id: null }]);
+              if (contAction?.id) {
+                await sql`
+                  UPDATE hive_backlog SET dispatch_id = ${contAction.id} WHERE id = ${completed_id}
+                `.catch(() => {});
+              }
             }
           }
         } catch (e) {
@@ -734,12 +751,28 @@ export async function POST(req: Request) {
             });
 
             if (contRes.ok || contRes.status === 204) {
+              // Use in_progress (not dispatched) so the 30-min stale dispatch cleanup doesn't
+              // reset this item while the continuation is still running.
               await sql`
                 UPDATE hive_backlog
-                SET status = 'dispatched', dispatched_at = NOW(),
+                SET status = 'in_progress', dispatched_at = NOW(),
                     notes = COALESCE(notes, '') || ${` [continued] Continuation dispatch after partial progress (${turnsUsed} turns → ${continuationTurns} turns). Last: ${lastCommit.slice(0, 80)}`}
                 WHERE id = ${completed_id}
               `.catch((e: any) => { console.warn(`[backlog] mark ${completed_id} as continued failed: ${e?.message || e}`); });
+              // Create an agent_actions record so the engineer_busy gate blocks concurrent
+              // dispatches during the continuation.
+              const [contAction] = await sql`
+                INSERT INTO agent_actions (agent, action_type, status, description, started_at)
+                VALUES ('engineer', 'feature_request', 'running',
+                  ${`Continuation (failed handler): "${item.title}" (${item.priority}, ${continuationTurns} turns)`},
+                  NOW())
+                RETURNING id
+              `.catch(() => [{ id: null }]);
+              if (contAction?.id) {
+                await sql`
+                  UPDATE hive_backlog SET dispatch_id = ${contAction.id} WHERE id = ${completed_id}
+                `.catch(() => {});
+              }
               continued = true;
               console.log(`[backlog] Continuation dispatched for "${item.title}" with ${continuationTurns} turns`);
             }


### PR DESCRIPTION
## Summary

Fixes Issue #215 — partial completion chain never dispatches the next backlog item.

**Root cause:** Both the `partial` and `failed` handler continuation paths set `status='dispatched'` after re-dispatching to GitHub Actions. The 30-min stale dispatch cleanup targets only `dispatched` items, so when a continuation ran longer than 30 minutes, the item was reset to `ready` mid-run. When the continuation eventually succeeded, the success handler WHERE clause (`status IN ('dispatched','in_progress')`) missed the reset item — so no QStash chain fired and no next backlog item was dispatched.

**Fix:**
- Change `status='dispatched'` → `status='in_progress'` in both continuation paths (`partial` handler + `failed` handler)
- Create an `agent_actions` record with `status='running'` after each continuation dispatch so the `engineer_busy` gate correctly blocks concurrent dispatches during the continuation window
- Link the new record via `dispatch_id` on the backlog item

Closes #215

## Test plan
- [ ] Continuation dispatch sets `status='in_progress'` (visible in DB after dispatch)
- [ ] Stale cleanup (`dispatched` items > 30 min) does NOT reset `in_progress` items
- [ ] `engineer_busy` gate blocks a second dispatch while continuation is running (agent_actions record exists)
- [ ] When continuation succeeds, success handler WHERE clause matches (`in_progress`) and QStash chain fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)