### PR TITLE
fix: reduce zombie action window from 1h to 35min, log on cancel

### DIFF
--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -1223,7 +1223,7 @@ jobs:
           fi
 
       - name: Log failure to Hive API
-        if: failure()
+        if: failure() || cancelled()
         env:
           PAYLOAD_JSON: ${{ needs.context.outputs.payload }}
         run: |

--- a/src/app/api/cron/sentinel-dispatch/route.ts
+++ b/src/app/api/cron/sentinel-dispatch/route.ts
@@ -770,16 +770,18 @@ async function executeSentinelDispatch(request: Request) {
     `;
 
     // ========================================================================
-    // 13b2: Task stealability — stale running agent_actions (stuck >1h)
+    // 13b2: Task stealability — stale running agent_actions (stuck >35 min)
+    // Threshold is set above the longest job timeout (build-hive: 30 min) so we
+    // never false-positive on legitimately running jobs, but catch zombies quickly.
     // ========================================================================
 
     const staleRunning = await sql`
       UPDATE agent_actions
       SET status = 'failed',
-          error = 'Stale: marked failed by Sentinel after 1h+ in running state (likely GitHub Actions crash/timeout)',
+          error = 'Stale: marked failed by Sentinel after 35+ min in running state (likely GitHub Actions crash/timeout)',
           finished_at = NOW()
       WHERE status = 'running'
-      AND started_at < NOW() - INTERVAL '1 hour'
+      AND started_at < NOW() - INTERVAL '35 minutes'
       AND agent IN ('engineer', 'growth', 'ceo', 'scout', 'healer', 'evolver')
       RETURNING id, agent, company_id
     `;


### PR DESCRIPTION
## Summary

- **Sentinel stale cleanup**: 1 hour → 35 minutes. Longest job timeout is 30 min (`build-hive`), so 35 min is safely above that to avoid false positives while catching zombies 25 min faster.
- **Engineer log-failure step**: \`if: failure()\` → \`if: failure() || cancelled()\` so GitHub Actions job cancellations (OOM kill, manual cancel) send a completion callback instead of leaving the \`agent_actions\` row in \`running\` state until Sentinel sweeps.

The heartbeat mechanism from the issue description was intentionally deferred — the two changes above eliminate the practical problem (company blocked for 1h+) with minimal code change.

Closes #261

## Test plan

- [ ] Trigger an engineer dispatch, manually cancel the job mid-run — verify `agent_actions` row is set to `failed` by the cancelled-triggered log step
- [ ] Verify stale threshold: create a `running` agent_action with `started_at = NOW() - 34 min`, confirm Sentinel does NOT clean it up; set `started_at = NOW() - 36 min`, confirm it IS cleaned up
- [ ] Verify Sentinel error message updated to "35+ min"

🤖 Generated with [Claude Code](https://claude.com/claude-code)