### PR TITLE
P2: CEO structured dispatch signals replacing brittle regex

### DIFF
--- a/.github/workflows/hive-ceo.yml
+++ b/.github/workflows/hive-ceo.yml
@@ -248,11 +248,11 @@ jobs:
             # Parallel worker dispatch — Growth/Outreach run on free models (OpenRouter/Gemini),
             # no Claude budget cost, so fire them concurrently with Engineer (not sequentially)
             {
-              echo "$RESULT" | grep -qiP "growth_tasks|growth_strategy|content.?calendar" && \
+              check_signal "dispatch_growth" && \
                 dispatch_to_company_repo "hive-growth.yml" "Growth cycle for $COMPANY" "growth"
             } &
             {
-              echo "$RESULT" | grep -qiP "outreach_tasks|lead.?list|cold.?email" && \
+              check_signal "dispatch_outreach" && \
                 dispatch_worker "outreach"
             } &
             # Wait for background worker dispatches (non-blocking, max 10s)

--- a/prompts/ceo.md
+++ b/prompts/ceo.md
@@ -75,9 +75,22 @@ Your plan MUST include validation context:
       }
     ],
     "reasoning": "Why these priorities. Must reference validation data.",
-    "directives_addressed": ["directive_id1"]
+    "directives_addressed": ["directive_id1"],
+    "dispatch_signals": {
+      "dispatch_growth": true,
+      "dispatch_outreach": false,
+      "needs_provisioning": false,
+      "needs_research": false
+    }
   }
 }
+```
+
+`dispatch_signals` controls which downstream agents run after this cycle:
+- `dispatch_growth`: set `true` if you included any `growth_tasks` in the plan
+- `dispatch_outreach`: set `true` if the company needs lead gen or cold email work this cycle
+- `needs_provisioning`: set `true` only for new companies that haven't been provisioned yet
+- `needs_research`: set `true` if market research is needed before the next cycle
 ```
 
 ### Bounded Context Planning


### PR DESCRIPTION
## Summary
- Replaced `grep -qiP "growth_tasks|growth_strategy|content.?calendar"` and `grep -qiP "outreach_tasks|lead.?list|cold.?email"` prose regex with structured `check_signal "dispatch_growth"` and `check_signal "dispatch_outreach"` in CEO chain dispatch
- Added `dispatch_signals` JSON block to `prompts/ceo.md` planning output schema so CEO explicitly sets boolean flags that control downstream dispatch
- Eliminates false positives from prose matching (e.g. "no growth_tasks needed" was triggering growth dispatch)

## Test plan
- [ ] CEO cycle_start output with `"dispatch_growth": true` triggers hive-growth.yml
- [ ] CEO cycle_start output with `"dispatch_growth": false` skips growth dispatch
- [ ] Same for `dispatch_outreach`
- [ ] Prose mentions of "growth" or "outreach" in summary text no longer cause false dispatches

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)