### PR TITLE
P2: Post-merge metric refresh via QStash delayed publish

### DIFF
--- a/src/app/api/cron/metrics/route.ts
+++ b/src/app/api/cron/metrics/route.ts
@@ -8,11 +8,12 @@ import { setSentryTags } from "@/lib/sentry-tags";
 // Collects page_views from each company's /api/stats endpoint
 // Also checks latest post-deploy smoke test results via GitHub API
 // Each company app tracks its own pageviews via middleware → page_views table
+// Supports company_slug query/body param for targeted single-company refresh (e.g. post-merge)
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-export async function GET(req: Request) {
+async function collectMetrics(req: Request, companySlugs?: string[]) {
   setSentryTags({
     action_type: "cron",
     route: "/api/cron/metrics",
@@ -27,12 +28,19 @@ export async function GET(req: Request) {
   const today = new Date().toISOString().split("T")[0];
   const ghToken = await getSettingValue("github_token").catch(() => null);
 
-  // Get all active/mvp companies with their URLs
-  const companies = await sql`
-    SELECT c.id, c.slug, COALESCE(c.domain, c.vercel_url) as app_url
-    FROM companies c
-    WHERE c.status IN ('active', 'mvp')
-  `;
+  // Get active/mvp companies — optionally filtered to specific slugs
+  const companies = companySlugs?.length
+    ? await sql`
+        SELECT c.id, c.slug, COALESCE(c.domain, c.vercel_url) as app_url
+        FROM companies c
+        WHERE c.status IN ('active', 'mvp')
+        AND c.slug = ANY(${companySlugs})
+      `
+    : await sql`
+        SELECT c.id, c.slug, COALESCE(c.domain, c.vercel_url) as app_url
+        FROM companies c
+        WHERE c.status IN ('active', 'mvp')
+      `;
 
   const results: Array<{ slug: string; views: number; pricing_clicks: number; affiliate_clicks: number; smoke_test_pass: boolean | null; source: string }> = [];
 
@@ -118,5 +126,21 @@ export async function GET(req: Request) {
   return Response.json({ ok: true, collected: results.length, results });
 }
 
-// QStash sends POST — re-export GET handler for dual-mode auth
-export { GET as POST };
+export async function GET(req: Request) {
+  // Support ?company_slug=X for targeted refresh
+  const { searchParams } = new URL(req.url);
+  const slug = searchParams.get("company_slug");
+  return collectMetrics(req, slug ? [slug] : undefined);
+}
+
+export async function POST(req: Request) {
+  // QStash sends POST with optional JSON body { company_slug: "X" }
+  let slug: string | undefined;
+  try {
+    const body = await req.json().catch(() => ({}));
+    slug = body?.company_slug || undefined;
+  } catch {
+    // no body — full refresh
+  }
+  return collectMetrics(req, slug ? [slug] : undefined);
+}

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -415,6 +415,13 @@ export async function POST(req: Request) {
                   )
                 `.catch(() => {});
 
+                // Schedule metric refresh 15 minutes after merge so new deploy has time to go live
+                qstashPublish("/api/cron/metrics", { company_slug: prRepo }, {
+                  delay: 900,
+                  retries: 2,
+                  deduplicationId: `metrics-${prRepo}-${prNumber}`,
+                }).catch(() => {});
+
                 // Telegram notification
                 import("@/lib/telegram").then(({ notifyHive }) =>
                   notifyHive({


### PR DESCRIPTION
## Summary
- After a company PR is merged, schedules a QStash delayed message (15-min delay) to `/api/cron/metrics` with `company_slug` so metrics are collected after the deploy is live
- Metrics endpoint (`/api/cron/metrics`) now accepts `company_slug` filter: query param for GET, JSON body for POST — limits collection to a single company when set
- Uses `deduplicationId: metrics-{company}-{pr}` to prevent duplicate refreshes if webhook fires twice

## Test plan
- [ ] Merge a company PR → QStash message scheduled 15 min out to `/api/cron/metrics`
- [ ] POST `/api/cron/metrics` with `{"company_slug": "senhorio"}` → only collects senhorio metrics
- [ ] GET `/api/cron/metrics?company_slug=senhorio` → same scoped collection
- [ ] GET `/api/cron/metrics` (no param) → still collects all companies as before

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)