### PR TITLE
P2: Healer verification pipeline — 30min post-fix QStash check

### DIFF
--- a/.github/workflows/hive-healer.yml
+++ b/.github/workflows/hive-healer.yml
@@ -191,6 +191,53 @@ jobs:
           "
           echo "Logged Healer success (${TURNS} turns, subtype=${SUBTYPE}, cost=\$${COST})"
 
+      - name: Schedule post-fix verification
+        if: steps.agent.outcome == 'success'
+        env:
+          SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || 'systemic' }}
+          HIVE_URL: ${{ secrets.NEXT_PUBLIC_URL || 'https://hive-phi.vercel.app' }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          # Only schedule verification for company-specific heals (not systemic)
+          if [ -z "$SCOPE" ] || [ "$SCOPE" = "systemic" ] || [ "$SCOPE" = "null" ]; then
+            echo "Systemic heal — skipping per-company verification"
+            exit 0
+          fi
+
+          # Look up company_id for the scope slug
+          npm install --no-save postgres 2>/dev/null
+          COMPANY_ID=$(node -e "
+          const postgres = require('postgres');
+          const sql = postgres(process.env.DATABASE_URL);
+          sql\`SELECT id FROM companies WHERE slug = '${SCOPE}' LIMIT 1\`
+            .then(r => { console.log(r[0]?.id || ''); sql.end(); })
+            .catch(() => { console.log(''); process.exit(0); });
+          " 2>/dev/null)
+
+          if [ -z "$COMPANY_ID" ]; then
+            echo "Could not resolve company_id for scope=${SCOPE} — skipping verification"
+            exit 0
+          fi
+
+          HEALED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          if [ -n "$QSTASH_TOKEN" ]; then
+            # Schedule via QStash with 30-minute delay
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+              "https://qstash.upstash.io/v2/publish/${HIVE_URL}/api/healer/verify" \
+              -H "Authorization: Bearer ${QSTASH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -H "Upstash-Delay: 1800s" \
+              -H "Upstash-Retries: 2" \
+              -H "Authorization: Bearer ${CRON_SECRET}" \
+              -d "{\"company_id\":\"${COMPANY_ID}\",\"company_slug\":\"${SCOPE}\",\"healed_at\":\"${HEALED_AT}\"}")
+            echo "QStash verification scheduled (HTTP ${HTTP_STATUS}) for ${SCOPE} in 30 min"
+          else
+            echo "QSTASH_TOKEN not set — verification step skipped (non-fatal)"
+          fi
+
       - name: Chain dispatch after heal
         if: steps.agent.outcome == 'success'
         env:

--- a/src/app/api/healer/verify/route.ts
+++ b/src/app/api/healer/verify/route.ts
@@ -1,0 +1,130 @@
+import { getDb, json, err } from "@/lib/db";
+import { verifyCronAuth } from "@/lib/qstash";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+// POST /api/healer/verify
+// Called via QStash with a 30-minute delay after Healer fixes an error.
+// Checks whether:
+//   1. The same error pattern recurred for the affected company
+//   2. Subsequent agent actions for the company succeeded
+// If the error persisted, increments the circuit breaker failure count.
+// If agents succeeded, records a healer success action to improve the circuit breaker success rate.
+
+export async function POST(req: Request) {
+  const auth = await verifyCronAuth(req);
+  if (!auth.authorized) {
+    return Response.json({ error: auth.error }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const { company_id, company_slug, error_pattern, healed_at } = body;
+
+  if (!company_id || !healed_at) {
+    return err("Missing required fields: company_id, healed_at");
+  }
+
+  const sql = getDb();
+  const healedAtDate = new Date(healed_at);
+
+  try {
+    // 1. Check if same error pattern recurred since the heal
+    const recurredErrors = await sql`
+      SELECT id, agent, error, description, finished_at
+      FROM agent_actions
+      WHERE company_id = ${company_id}
+        AND status = 'failed'
+        AND finished_at > ${healedAtDate}
+        AND finished_at > NOW() - INTERVAL '1 hour'
+        ${error_pattern
+          ? sql`AND (
+              error ILIKE ${"%" + error_pattern + "%"}
+              OR description ILIKE ${"%" + error_pattern + "%"}
+            )`
+          : sql``}
+      ORDER BY finished_at DESC
+      LIMIT 5
+    `.catch(() => [] as any[]);
+
+    // 2. Check if subsequent agent actions succeeded after the heal
+    const successfulActions = await sql`
+      SELECT id, agent, action_type, finished_at
+      FROM agent_actions
+      WHERE company_id = ${company_id}
+        AND status = 'success'
+        AND finished_at > ${healedAtDate}
+        AND finished_at > NOW() - INTERVAL '1 hour'
+        AND agent != 'healer'
+      ORDER BY finished_at DESC
+      LIMIT 5
+    `.catch(() => [] as any[]);
+
+    const errorRecurred = recurredErrors.length > 0;
+    const agentsSucceeded = successfulActions.length > 0;
+
+    if (errorRecurred) {
+      // Fix didn't hold — log a healer failure to worsen the circuit breaker
+      await sql`
+        INSERT INTO agent_actions (agent, action_type, status, description, company_id, started_at, finished_at)
+        VALUES (
+          'healer', 'verify_fix', 'failed',
+          ${`Post-fix verification FAILED for ${company_slug || company_id}: error recurred ${recurredErrors.length}x within 30 min. Pattern: ${error_pattern || "unknown"}`},
+          ${company_id}, NOW(), NOW()
+        )
+      `.catch(() => {});
+
+      return json({
+        verified: false,
+        error_recurred: true,
+        recurrence_count: recurredErrors.length,
+        agents_succeeded: agentsSucceeded,
+        company_id,
+        company_slug,
+      });
+    }
+
+    if (agentsSucceeded) {
+      // Fix held and agents are working — record a strong success signal
+      await sql`
+        INSERT INTO agent_actions (agent, action_type, status, description, company_id, started_at, finished_at)
+        VALUES (
+          'healer', 'verify_fix', 'success',
+          ${`Post-fix verification PASSED for ${company_slug || company_id}: ${successfulActions.length} agent(s) succeeded after fix. Pattern: ${error_pattern || "unknown"}`},
+          ${company_id}, NOW(), NOW()
+        )
+      `.catch(() => {});
+
+      return json({
+        verified: true,
+        error_recurred: false,
+        agents_succeeded: true,
+        successful_agents: successfulActions.map((a: any) => a.agent),
+        company_id,
+        company_slug,
+      });
+    }
+
+    // No errors, no successes — inconclusive (agents may not have run yet)
+    await sql`
+      INSERT INTO agent_actions (agent, action_type, status, description, company_id, started_at, finished_at)
+      VALUES (
+        'healer', 'verify_fix', 'success',
+        ${`Post-fix verification inconclusive for ${company_slug || company_id}: no errors recurred, but no agents ran yet. Pattern: ${error_pattern || "unknown"}`},
+        ${company_id}, NOW(), NOW()
+      )
+    `.catch(() => {});
+
+    return json({
+      verified: true,
+      error_recurred: false,
+      agents_succeeded: false,
+      inconclusive: true,
+      company_id,
+      company_slug,
+    });
+
+  } catch (error) {
+    return err(`Verification failed: ${error instanceof Error ? error.message : "unknown"}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `/api/healer/verify` POST endpoint that runs 30 minutes after a Healer fix
- Checks whether the fixed error recurred or subsequent agents succeeded
- Records outcome in `agent_actions` as `verify_fix` action type, feeding into the circuit breaker success rate
- Updates `hive-healer.yml` to schedule the check via QStash on every company-specific heal

## How it works

1. Healer finishes fixing a company error
2. New "Schedule post-fix verification" step looks up `company_id` from slug, publishes to QStash with `Upstash-Delay: 1800s`
3. 30 minutes later, `/api/healer/verify` fires and queries:
   - Did the same error pattern recur? → logs `verify_fix` failure (worsens circuit breaker)
   - Did any other agents succeed? → logs `verify_fix` success (improves circuit breaker)
   - Neither → inconclusive, logs success (neutral)
4. Circuit breaker naturally deprioritises companies where healer fixes don't hold

## Test plan

- [ ] CI passes
- [ ] `/api/healer/verify` returns 401 without auth, 200 with valid body
- [ ] Workflow step skips gracefully when `QSTASH_TOKEN` not set
- [ ] Workflow step skips for `scope=systemic`

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)