### PR TITLE
feat: integrate frontend-design skill into Engineer agent

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Apache 2.0 — https://github.com/anthropics/skills/blob/main/skills/frontend-design/LICENSE.txt
+source: https://github.com/anthropics/skills/tree/main/skills/frontend-design
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+
+## Hive-Specific Notes
+
+When applying this skill in a company context:
+1. **Read `globals.css` first** — it defines design tokens. The skill's aesthetic vision must work within (or consciously extend) those tokens.
+2. **Landing pages and marketing sites** have the most creative freedom. Apply the full skill.
+3. **Dashboards and admin UIs** — apply typography and color principles; limit animations to micro-interactions only.
+4. **Blog layouts** — apply editorial/magazine aesthetic direction from the skill.
+5. **Each company gets a unique design identity.** Do not reuse the same font or color palette across different portfolio companies.

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -58,6 +58,7 @@ Before writing frontend code, configuring styling, or triggering deployments, re
 
 | When to use | Skill file |
 |------------|------------|
+| Building or redesigning landing pages, marketing sites, blog layouts | `.claude/skills/frontend-design/SKILL.md` — bold design direction, distinctive typography, memorable aesthetics, anti-slop principles |
 | Writing or reviewing any Tailwind CSS | `.claude/skills/tailwind-4-docs/SKILL.md` — Tailwind v4 utilities, variants, config, migration from v3 |
 | Writing React components, Next.js pages, data fetching | `.claude/skills/vercel-react-best-practices/SKILL.md` — 65 performance rules from Vercel Engineering |
 | Deploying to Vercel, creating preview deployments | `.claude/skills/deploy-to-vercel/SKILL.md` — deployment actions and Vercel CLI steps |
@@ -108,7 +109,10 @@ These skills are checked into the Hive repo (not the company repo). Read them wi
 - No console.log in production code (use structured logging if available).
 
 ### Visual quality standards
-Read `globals.css` before writing ANY UI code. It contains design tokens and rules. Follow them strictly:
+
+**For landing pages, marketing sites, and blog layouts:** Read `.claude/skills/frontend-design/SKILL.md` BEFORE writing any UI code. Commit to a bold aesthetic direction specific to this company. Every company must have a distinct visual identity — no two portfolio companies should share the same font or color palette.
+
+Read `globals.css` before writing ANY UI code. It contains design tokens and rules. Follow them strictly. The frontend-design skill's aesthetic vision must be expressed through (or extend) these tokens — not override the token system itself.
 
 1. **Use design tokens, not raw values.** Use `text-brand`, `bg-accent`, `text-text-secondary`, `border-border` etc. Never write raw hex colors (`#3b82f6`) or arbitrary Tailwind colors (`text-blue-600`) in components.
 2. **No gradients.** No `bg-gradient-to-*`, no `from-*`, no gradient text. Solid colors only.


### PR DESCRIPTION
## Summary

- Creates `.claude/skills/frontend-design/SKILL.md` with the full Anthropic frontend-design skill content + Hive-specific notes (when to use bold vs restrained aesthetics, per-company uniqueness rule)
- Adds skill to Engineer's Skill Catalog as the first row — triggers on landing pages, marketing sites, blog layouts
- Adds mandatory read directive before writing marketing UI code: read skill → commit to a bold aesthetic → then proceed with globals.css tokens
- Enforces that no two portfolio companies share the same font or color palette

Closes #241

## Test plan

- [x] `npx next build` passes
- [x] Skill file has clear Hive-specific guidance on landing page vs dashboard vs blog contexts
- [x] Engineer prompt skill catalog updated with correct trigger condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)