### PR TITLE
chore: add npm caching to agent GitHub Actions workflows

### DIFF
--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Checkout Hive (for templates)
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Get tokens via OIDC
         id: auth
         uses: ./.github/actions/get-hive-tokens
@@ -571,6 +577,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Checkout Hive
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Get tokens via OIDC
         id: auth
         uses: ./.github/actions/get-hive-tokens

--- a/.github/workflows/hive-healer.yml
+++ b/.github/workflows/hive-healer.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Configure git
         run: |
           git config user.name "Hive Healer"

--- a/.github/workflows/hive-spec-gen.yml
+++ b/.github/workflows/hive-spec-gen.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Checkout Hive
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Extract payload
         id: payload
         run: |


### PR DESCRIPTION
## Summary
- Adds `actions/setup-node@v4` with `cache: 'npm'` to three workflows that had inline `npm install` calls but no Node.js setup step
- `hive-healer.yml`: provision job (2x `npm install --no-save postgres`)
- `hive-spec-gen.yml`: main job (3x `npm install --no-save postgres/@neondatabase/serverless`)
- `hive-engineer.yml`: provision job + teardown job; teardown also gets a missing `actions/checkout@v4` (was using local composite action without checkout — bug fix included)

npm cache hits will avoid re-downloading packages on subsequent runs, saving ~10-30s per run.

Closes #150

## Test plan
- [ ] CI passes (actionlint, lint-and-build)
- [ ] Workflow syntax is valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)