### PR TITLE
refactor: extract CEO chain dispatch bash to TypeScript utility

### DIFF
--- a/.github/workflows/hive-ceo.yml
+++ b/.github/workflows/hive-ceo.yml
@@ -129,174 +129,22 @@ jobs:
           cron_secret: ${{ steps.auth.outputs.cron_secret }}
           context_payload: ${{ steps.context.outputs.payload }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Chain dispatch
         if: always() && steps.agent.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.auth.outputs.gh_pat }}
           CRON_SECRET: ${{ steps.auth.outputs.cron_secret }}
           HIVE_URL: https://hive-phi.vercel.app
+          EXECUTION_FILE: ${{ steps.agent.outputs.execution_file }}
+          TRIGGER: ${{ steps.context.outputs.trigger }}
           DISPATCH_PAYLOAD: ${{ toJson(github.event.client_payload) }}
-        run: |
-          set +e  # Prevent grep/jq exit codes from crashing the step
-          RESULT=$(jq -r '[.[] | select(.type == "assistant")] | last | [.message.content[] | select(.type == "text") | .text] | join("\n")' "${{ steps.agent.outputs.execution_file }}" 2>/dev/null || echo "{}")
-          REPO="${{ github.repository }}"
-          TRIGGER="${{ steps.context.outputs.trigger }}"
-          TRACE_ID=$(echo "${DISPATCH_PAYLOAD}" | jq -r '.trace_id // empty' 2>/dev/null || echo "")
-          echo "Chain dispatch parsing last assistant output (${#RESULT} chars)"
-          echo "Trigger: $TRIGGER"
-          echo "Trace ID: $TRACE_ID"
-
-          dispatch() {
-            curl -s -X POST "https://api.github.com/repos/$REPO/dispatches" \
-              -H "Authorization: token $GH_TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -d "{\"event_type\":\"$1\",\"client_payload\":$2}"
-            echo "  Dispatched: $1"
-          }
-
-          # Extract company: try output first, then input payload (multiple fallbacks)
-          COMPANY=$(echo "$RESULT" | grep -oP '"company"\s*:\s*"\K[^"]+' | head -1 || echo "")
-          if [ -z "$COMPANY" ]; then
-            COMPANY=$(echo "${DISPATCH_PAYLOAD}" | jq -r '.company // ""' 2>/dev/null || echo "")
-          fi
-          # Also extract company_id for downstream agents
-          COMPANY_ID=$(echo "$RESULT" | grep -oP '"company_id"\s*:\s*"\K[^"]+' | head -1 || echo "")
-          if [ -z "$COMPANY_ID" ]; then
-            COMPANY_ID=$(echo "${DISPATCH_PAYLOAD}" | jq -r '.company_id // ""' 2>/dev/null || echo "")
-          fi
-          GITHUB_REPO=""
-          echo "Company: $COMPANY | Company ID: $COMPANY_ID"
-
-          # Guard: if no company found, skip all dispatches
-          if [ -z "$COMPANY" ]; then
-            echo "WARNING: No company slug found in output or payload — skipping dispatches"
-            echo "Chain dispatch complete (no company)"
-            exit 0
-          fi
-
-          # Detect signals: strict JSON-only matching (no prose matching to avoid false positives)
-          check_signal() {
-            echo "$RESULT" | grep -qP "\"${1}\"\s*:\s*true" && return 0
-            return 1
-          }
-
-          # Build reusable payload with company + company_id + trace_id
-          BASE_PAYLOAD="\"company\":\"$COMPANY\",\"company_id\":\"$COMPANY_ID\""
-          if [ -n "$TRACE_ID" ]; then
-            BASE_PAYLOAD="$BASE_PAYLOAD,\"trace_id\":\"$TRACE_ID\""
-          fi
-
-          # Only dispatch downstream agents for cycle_start (not cycle_complete — avoids infinite loop)
-          IS_CYCLE_START=false
-          echo "$TRIGGER" | grep -q "cycle_start" && IS_CYCLE_START=true
-
-          if [ "$IS_CYCLE_START" = "true" ]; then
-            # Chain to Engineer for provisioning (only if explicitly flagged)
-            if check_signal "needs_provisioning"; then
-              dispatch "new_company" "{\"source\":\"ceo\",$BASE_PAYLOAD}"
-            fi
-
-            # Chain to Scout if research needed
-            if check_signal "needs_research"; then
-              dispatch "research_request" "{\"source\":\"ceo\",$BASE_PAYLOAD}"
-            fi
-
-            # Define dispatch helpers (must be before first call)
-            dispatch_worker() {
-              local WORKER_PAYLOAD="{\"company_slug\":\"$COMPANY\",\"agent\":\"$1\",\"trigger\":\"ceo_plan\""
-              if [ -n "$TRACE_ID" ]; then
-                WORKER_PAYLOAD="$WORKER_PAYLOAD,\"trace_id\":\"$TRACE_ID\""
-              fi
-              WORKER_PAYLOAD="$WORKER_PAYLOAD}"
-              curl -s -X POST "$HIVE_URL/api/agents/dispatch" \
-                -H "Authorization: Bearer $CRON_SECRET" \
-                -H "Content-Type: application/json" \
-                -d "$WORKER_PAYLOAD" \
-                -o /dev/null -w "  Worker $1: HTTP %{http_code}\n" || true
-            }
-            dispatch_to_company_repo() {
-              local WORKFLOW="$1" SUMMARY="$2"
-              # Get company's github_repo from DB (cached after first call)
-              if [ -z "$GITHUB_REPO" ]; then
-                GITHUB_REPO=$(node -e "
-                  const postgres = require('postgres');
-                  const sql = postgres(process.env.DATABASE_URL);
-                  sql\`SELECT github_repo FROM companies WHERE slug = '${COMPANY}' LIMIT 1\`
-                    .then(r => { console.log(r[0]?.github_repo || ''); sql.end(); })
-                    .catch(() => { console.log(''); process.exit(0); });
-                " 2>/dev/null)
-              fi
-              if [ -n "$GITHUB_REPO" ]; then
-                curl -s -X POST "https://api.github.com/repos/${GITHUB_REPO}/actions/workflows/${WORKFLOW}/dispatches" \
-                  -H "Authorization: token $GH_TOKEN" \
-                  -H "Accept: application/vnd.github.v3+json" \
-                  -H "Content-Type: application/json" \
-                  -d "{\"ref\":\"main\",\"inputs\":{\"company_slug\":\"$COMPANY\",\"trigger\":\"ceo_plan\",\"task_summary\":\"$SUMMARY\"}}" \
-                  -o /dev/null -w "  Company $WORKFLOW: HTTP %{http_code}\n" || dispatch_worker "$3"
-              else
-                dispatch_worker "$3"
-              fi
-            }
-
-            # Chain to Engineer → dispatch directly to company repo (free Actions)
-            # Falls back to Hive Engineer only if no company repo exists
-            dispatch_to_company_repo "hive-build.yml" "Feature build for $COMPANY" ""
-            if [ -z "$GITHUB_REPO" ]; then
-              dispatch "feature_request" "{\"source\":\"ceo\",$BASE_PAYLOAD}"
-            fi
-
-            # Parallel worker dispatch — Growth/Outreach run on free models (OpenRouter/Gemini),
-            # no Claude budget cost, so fire them concurrently with Engineer (not sequentially)
-            {
-              check_signal "dispatch_growth" && \
-                dispatch_to_company_repo "hive-growth.yml" "Growth cycle for $COMPANY" "growth"
-            } &
-            {
-              check_signal "dispatch_outreach" && \
-                dispatch_worker "outreach"
-            } &
-            # Wait for background worker dispatches (non-blocking, max 10s)
-            wait
-
-            # Dispatch cycle_complete ONCE (for review/reflection after agents finish)
-            dispatch "cycle_complete" "{\"source\":\"ceo\",$BASE_PAYLOAD}"
-          fi
-
-          # For gate_approved: only dispatch the specific action needed
-          if echo "$TRIGGER" | grep -q "gate_approved"; then
-            if check_signal "needs_provisioning"; then
-              dispatch "new_company" "{\"source\":\"ceo\",$BASE_PAYLOAD}"
-            fi
-          fi
-
-          # cycle_complete / ceo_review: trigger post-cycle consolidation + chain next company
-          # This feeds CEO review outcomes back into the playbook (learning loop)
-          if echo "$TRIGGER" | grep -qE "cycle_complete|ceo_review"; then
-            echo "Triggering post-cycle consolidation..."
-            curl -s -X POST "$HIVE_URL/api/agents/consolidate" \
-              -H "Authorization: Bearer $CRON_SECRET" \
-              -H "Content-Type: application/json" \
-              -d "{\"company_slug\":\"$COMPANY\"}" \
-              -o /dev/null -w "  Consolidation: HTTP %{http_code}\n" || true
-
-            # Chain dispatch: cycle done → health gate → next company
-            echo "Chaining to next company cycle..."
-            CHAIN_RESULT=$(curl -s -X POST "$HIVE_URL/api/dispatch/cycle-complete" \
-              -H "Authorization: Bearer $CRON_SECRET" \
-              -H "Content-Type: application/json" \
-              -d "{\"agent\":\"ceo\",\"company\":\"$COMPANY\",\"status\":\"cycle_complete\",\"action_type\":\"cycle_review\"}")
-            echo "  Chain result: $CHAIN_RESULT"
-          fi
-
-          # Notify success via Telegram
-          EXEC_FILE="${{ steps.agent.outputs.execution_file }}"
-          if [ -z "$EXEC_FILE" ]; then EXEC_FILE="/home/runner/work/_temp/claude-execution-output.json"; fi
-          CEO_TURNS=$(jq -r '.[-1].num_turns // 0' "$EXEC_FILE" 2>/dev/null || echo "0")
-          CEO_COST=$(jq -r '.[-1].total_cost_usd // 0' "$EXEC_FILE" 2>/dev/null || echo "0")
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          curl -s -X POST "$HIVE_URL/api/notify" \
-            -H "Authorization: Bearer $CRON_SECRET" \
-            -H "Content-Type: application/json" \
-            -d "{\"agent\":\"ceo\",\"action\":\"$TRIGGER\",\"company\":\"$COMPANY\",\"status\":\"success\",\"summary\":\"Completed in ${CEO_TURNS} turns (\$${CEO_COST})\",\"run_url\":\"$RUN_URL\",\"duration_s\":$((CEO_TURNS * 60))}" || true
-
-          echo "Chain dispatch complete"
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: npx tsx scripts/chain-dispatch.ts

--- a/scripts/chain-dispatch.ts
+++ b/scripts/chain-dispatch.ts
@@ -1,0 +1,356 @@
+/**
+ * CEO Chain Dispatch — TypeScript replacement for the bash chain dispatch block
+ * in hive-ceo.yml.
+ *
+ * Usage: npx tsx scripts/chain-dispatch.ts
+ *
+ * Required env vars:
+ *   EXECUTION_FILE    — path to claude-code-action execution JSON
+ *   GH_TOKEN          — GitHub PAT for repository_dispatch calls
+ *   CRON_SECRET       — Hive API auth token
+ *   HIVE_URL          — Hive base URL (e.g. https://hive-phi.vercel.app)
+ *   DATABASE_URL      — Neon connection string (for company repo lookup)
+ *   TRIGGER           — CEO trigger string (from steps.context.outputs.trigger)
+ *   DISPATCH_PAYLOAD  — raw JSON of github.event.client_payload
+ *   GITHUB_REPOSITORY — e.g. carloshmiranda/hive
+ *   GITHUB_RUN_ID     — current workflow run ID
+ *   GITHUB_SERVER_URL — e.g. https://github.com
+ */
+
+import { readFileSync } from "fs";
+import { neon } from "@neondatabase/serverless";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function env(key: string, fallback = ""): string {
+  return process.env[key] ?? fallback;
+}
+
+async function post(
+  url: string,
+  headers: Record<string, string>,
+  body: unknown
+): Promise<{ status: number; text: string }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, text };
+}
+
+// ─── Parse execution file ────────────────────────────────────────────────────
+
+function parseLastAssistantText(execFile: string): string {
+  try {
+    const raw = readFileSync(execFile, "utf-8");
+    const entries: unknown[] = JSON.parse(raw);
+    // Find last assistant entry with text content
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const entry = entries[i] as Record<string, unknown>;
+      if (entry.type !== "assistant") continue;
+      const msg = entry.message as Record<string, unknown> | undefined;
+      if (!msg) continue;
+      const content = msg.content as Array<Record<string, unknown>> | undefined;
+      if (!Array.isArray(content)) continue;
+      const texts = content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text as string)
+        .join("\n");
+      if (texts) return texts;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return "{}";
+}
+
+function parseExecutionMeta(execFile: string): { turns: number; cost: number } {
+  try {
+    const raw = readFileSync(execFile, "utf-8");
+    const entries: unknown[] = JSON.parse(raw);
+    const last = entries[entries.length - 1] as Record<string, unknown>;
+    return {
+      turns: Number(last?.num_turns ?? 0),
+      cost: Number(last?.total_cost_usd ?? 0),
+    };
+  } catch {
+    return { turns: 0, cost: 0 };
+  }
+}
+
+// ─── Signal detection ────────────────────────────────────────────────────────
+
+function checkSignal(result: string, signal: string): boolean {
+  return new RegExp(`"${signal}"\\s*:\\s*true`).test(result);
+}
+
+// ─── Company extraction ──────────────────────────────────────────────────────
+
+function extractCompany(
+  result: string,
+  payload: Record<string, unknown>
+): { company: string; companyId: string } {
+  const companyMatch = result.match(/"company"\s*:\s*"([^"]+)"/);
+  const company = companyMatch?.[1] ?? String(payload.company ?? "");
+
+  const idMatch = result.match(/"company_id"\s*:\s*"([^"]+)"/);
+  const companyId = idMatch?.[1] ?? String(payload.company_id ?? "");
+
+  return { company, companyId };
+}
+
+// ─── DB lookup for company repo ──────────────────────────────────────────────
+
+async function getCompanyGithubRepo(
+  company: string,
+  dbUrl: string
+): Promise<string> {
+  if (!dbUrl || !company) return "";
+  try {
+    const sql = neon(dbUrl);
+    const rows = await sql`SELECT github_repo FROM companies WHERE slug = ${company} LIMIT 1` as { github_repo: string }[];
+    return rows[0]?.github_repo ?? "";
+  } catch {
+    return "";
+  }
+}
+
+// ─── Dispatch functions ───────────────────────────────────────────────────────
+
+async function dispatchGithub(
+  repo: string,
+  eventType: string,
+  clientPayload: Record<string, unknown>,
+  ghToken: string
+): Promise<void> {
+  const { status } = await post(
+    `https://api.github.com/repos/${repo}/dispatches`,
+    {
+      Authorization: `token ${ghToken}`,
+      Accept: "application/vnd.github.v3+json",
+    },
+    { event_type: eventType, client_payload: clientPayload }
+  );
+  console.log(`  Dispatched: ${eventType} (HTTP ${status})`);
+}
+
+async function dispatchWorker(
+  agent: string,
+  company: string,
+  traceId: string,
+  hiveUrl: string,
+  cronSecret: string
+): Promise<void> {
+  const body: Record<string, string> = {
+    company_slug: company,
+    agent,
+    trigger: "ceo_plan",
+  };
+  if (traceId) body.trace_id = traceId;
+  const { status } = await post(
+    `${hiveUrl}/api/agents/dispatch`,
+    { Authorization: `Bearer ${cronSecret}` },
+    body
+  );
+  console.log(`  Worker ${agent}: HTTP ${status}`);
+}
+
+async function dispatchToCompanyRepo(
+  workflow: string,
+  summary: string,
+  fallbackAgent: string,
+  company: string,
+  githubRepo: string,
+  traceId: string,
+  ghToken: string,
+  hiveUrl: string,
+  cronSecret: string
+): Promise<void> {
+  if (githubRepo) {
+    const inputs: Record<string, string> = {
+      company_slug: company,
+      trigger: "ceo_plan",
+      task_summary: summary,
+    };
+    const { status } = await post(
+      `https://api.github.com/repos/${githubRepo}/actions/workflows/${workflow}/dispatches`,
+      {
+        Authorization: `token ${ghToken}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+      { ref: "main", inputs }
+    );
+    console.log(`  Company ${workflow}: HTTP ${status}`);
+    if (status >= 400 && fallbackAgent) {
+      await dispatchWorker(
+        fallbackAgent,
+        company,
+        traceId,
+        hiveUrl,
+        cronSecret
+      );
+    }
+  } else if (fallbackAgent) {
+    await dispatchWorker(fallbackAgent, company, traceId, hiveUrl, cronSecret);
+  }
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const execFile =
+    env("EXECUTION_FILE") ||
+    "/home/runner/work/_temp/claude-execution-output.json";
+  const ghToken = env("GH_TOKEN");
+  const cronSecret = env("CRON_SECRET");
+  const hiveUrl = env("HIVE_URL", "https://hive-phi.vercel.app");
+  const dbUrl = env("DATABASE_URL");
+  const trigger = env("TRIGGER");
+  const dispatchPayloadRaw = env("DISPATCH_PAYLOAD", "{}");
+  const repo = env("GITHUB_REPOSITORY");
+  const runId = env("GITHUB_RUN_ID");
+  const serverUrl = env("GITHUB_SERVER_URL", "https://github.com");
+
+  const dispatchPayload: Record<string, unknown> = (() => {
+    try {
+      return JSON.parse(dispatchPayloadRaw);
+    } catch {
+      return {};
+    }
+  })();
+
+  const result = parseLastAssistantText(execFile);
+  const traceId = String(dispatchPayload.trace_id ?? "");
+
+  console.log(`Chain dispatch parsing last assistant output (${result.length} chars)`);
+  console.log(`Trigger: ${trigger}`);
+  console.log(`Trace ID: ${traceId}`);
+
+  const { company, companyId } = extractCompany(result, dispatchPayload);
+  console.log(`Company: ${company} | Company ID: ${companyId}`);
+
+  if (!company) {
+    console.log("WARNING: No company slug found in output or payload — skipping dispatches");
+    console.log("Chain dispatch complete (no company)");
+    return;
+  }
+
+  const basePayload: Record<string, string> = {
+    company,
+    ...(companyId ? { company_id: companyId } : {}),
+    ...(traceId ? { trace_id: traceId } : {}),
+  };
+
+  const isCycleStart = trigger.includes("cycle_start");
+  const isGateApproved = trigger.includes("gate_approved");
+  const isCycleComplete = /cycle_complete|ceo_review/.test(trigger);
+
+  if (isCycleStart) {
+    // Provision new company if needed
+    if (checkSignal(result, "needs_provisioning")) {
+      await dispatchGithub(repo, "new_company", { source: "ceo", ...basePayload }, ghToken);
+    }
+
+    // Chain to Scout for research
+    if (checkSignal(result, "needs_research")) {
+      await dispatchGithub(repo, "research_request", { source: "ceo", ...basePayload }, ghToken);
+    }
+
+    // Look up company's GitHub repo (for free company-repo Actions)
+    const githubRepo = await getCompanyGithubRepo(company, dbUrl);
+
+    // Chain to Engineer → company repo hive-build.yml (fallback: Hive feature_request)
+    await dispatchToCompanyRepo(
+      "hive-build.yml",
+      `Feature build for ${company}`,
+      "",
+      company,
+      githubRepo,
+      traceId,
+      ghToken,
+      hiveUrl,
+      cronSecret
+    );
+    if (!githubRepo) {
+      await dispatchGithub(repo, "feature_request", { source: "ceo", ...basePayload }, ghToken);
+    }
+
+    // Parallel worker dispatches (Growth + Outreach) — these use free models, fire concurrently
+    await Promise.all([
+      checkSignal(result, "dispatch_growth")
+        ? dispatchToCompanyRepo(
+            "hive-growth.yml",
+            `Growth cycle for ${company}`,
+            "growth",
+            company,
+            githubRepo,
+            traceId,
+            ghToken,
+            hiveUrl,
+            cronSecret
+          )
+        : Promise.resolve(),
+      checkSignal(result, "dispatch_outreach")
+        ? dispatchWorker("outreach", company, traceId, hiveUrl, cronSecret)
+        : Promise.resolve(),
+    ]);
+
+    // Dispatch cycle_complete once (for review/reflection after agents finish)
+    await dispatchGithub(repo, "cycle_complete", { source: "ceo", ...basePayload }, ghToken);
+  }
+
+  if (isGateApproved) {
+    if (checkSignal(result, "needs_provisioning")) {
+      await dispatchGithub(repo, "new_company", { source: "ceo", ...basePayload }, ghToken);
+    }
+  }
+
+  if (isCycleComplete) {
+    console.log("Triggering post-cycle consolidation...");
+    const consolidateRes = await post(
+      `${hiveUrl}/api/agents/consolidate`,
+      { Authorization: `Bearer ${cronSecret}` },
+      { company_slug: company }
+    );
+    console.log(`  Consolidation: HTTP ${consolidateRes.status}`);
+
+    console.log("Chaining to next company cycle...");
+    const chainRes = await post(
+      `${hiveUrl}/api/dispatch/cycle-complete`,
+      { Authorization: `Bearer ${cronSecret}` },
+      {
+        agent: "ceo",
+        company,
+        status: "cycle_complete",
+        action_type: "cycle_review",
+      }
+    );
+    console.log(`  Chain result: ${chainRes.text}`);
+  }
+
+  // Notify via Telegram
+  const { turns, cost } = parseExecutionMeta(execFile);
+  const runUrl = `${serverUrl}/${repo}/actions/runs/${runId}`;
+  await post(
+    `${hiveUrl}/api/notify`,
+    { Authorization: `Bearer ${cronSecret}` },
+    {
+      agent: "ceo",
+      action: trigger,
+      company,
+      status: "success",
+      summary: `Completed in ${turns} turns ($${cost})`,
+      run_url: runUrl,
+      duration_s: turns * 60,
+    }
+  ).catch(() => {}); // non-fatal
+
+  console.log("Chain dispatch complete");
+}
+
+main().catch((err) => {
+  console.error("Chain dispatch error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Moves the 130-line bash `Chain dispatch` block from `hive-ceo.yml` into `scripts/chain-dispatch.ts`
- TypeScript version is fully typed (passes `tsc --noEmit`), uses `@neondatabase/serverless` (already a project dependency) instead of `npm install --no-save postgres` for the company repo DB lookup
- Adds `actions/setup-node@v4` with npm caching to the CEO workflow (consistent with PR #324 pattern)
- Workflow step reduces from ~130 lines bash to a single `npx tsx scripts/chain-dispatch.ts`

Closes #151

## Test plan

- [ ] CI actionlint, lint-and-build, validate pass
- [ ] No regressions to CEO workflow behavior (same dispatch logic, same signals, same API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)