### PR TITLE
feat: Sentry performance spans for LLM calls and GitHub dispatch

### DIFF
--- a/src/app/api/agents/dispatch/route.ts
+++ b/src/app/api/agents/dispatch/route.ts
@@ -9,7 +9,7 @@ import { getSuppressedEmails } from "@/lib/outreach-suppression";
 import { getResponseFormat, AGENT_SCHEMAS } from "@/lib/agent-schemas";
 import { HIVE_TOOLS } from "@/lib/hive-tools";
 import { sanitizeJSON, validateDispatchPayload, sanitizeTaskInput, hasSuspiciousPatterns } from "@/lib/input-sanitizer";
-import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
+import { setSentryTags, addDispatchBreadcrumb, withSpan } from "@/lib/sentry-tags";
 import { type CompletionReport } from "@/lib/completion-report";
 import { cachedPlaybook } from "@/lib/redis-cache";
 import { compressResearchForAgent } from "@/lib/research-compression";
@@ -353,13 +353,31 @@ ${capabilitiesSummary(company.capabilities)}`;
       data: { agent: agentName, company: company.slug },
     });
     const responseFormat = getResponseFormat(agentName as keyof typeof AGENT_SCHEMAS);
-    const { response, logData, toolResults } = await callLLMWithTools(agentName, fullPrompt, {
-      sql,
-      responseFormat,
-      tools: HIVE_TOOLS,
-      parallelToolCalls: true,
-      company: company.slug,
-    });
+
+    // Sentry performance span: measures LLM call duration for tracing in the performance tab
+    const { response, logData, toolResults } = await withSpan(
+      `LLM: ${agentName}`,
+      "ai.run",
+      { "ai.agent": agentName, "ai.company": company.slug },
+      async (span) => {
+        const result = await callLLMWithTools(agentName, fullPrompt, {
+          sql,
+          responseFormat,
+          tools: HIVE_TOOLS,
+          parallelToolCalls: true,
+          company: company.slug,
+        });
+        // Update span with actual provider/model resolved at runtime
+        span?.setAttributes({
+          "ai.provider": result.logData.provider,
+          "ai.model_id": result.logData.model,
+          "ai.duration_s": result.logData.duration_s,
+          "ai.cost_usd": result.logData.cost_usd ?? 0,
+          "ai.tool_calls": result.response.toolCalls?.length ?? 0,
+        });
+        return result;
+      }
+    );
     const output = response.content;
 
     addDispatchBreadcrumb({

--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -7,7 +7,7 @@ import { flagProblemStatementsAsNeedingDecomposition, isCompanySpecific } from "
 import { qstashPublish } from "@/lib/qstash";
 import { queuePop, queueRebuild, queueSyncItem } from "@/lib/redis-cache";
 import { sanitizeTaskInput, hasSuspiciousPatterns } from "@/lib/input-sanitizer";
-import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
+import { setSentryTags, addDispatchBreadcrumb, withSpan } from "@/lib/sentry-tags";
 import { writeCompletionReportByDispatchId, type CompletionReport } from "@/lib/completion-report";
 import type { PRAnalysis } from "@/lib/pr-risk-scoring";
 import { markTaskAsStealable, claimStealableTask, type WorkStealingResult } from "@/lib/work-stealing";
@@ -2338,12 +2338,30 @@ export async function POST(req: Request) {
     category: "github",
     data: { backlog_id: topItem.id, priority: topItem.priority, attempt: attemptCount + 1, payload_bytes: payloadStr.length },
   });
-  const res = await fetch("https://api.github.com/repos/carloshmiranda/hive/dispatches", {
-    method: "POST",
-    headers: { Authorization: `Bearer ${ghPat}`, Accept: "application/vnd.github.v3+json", "Content-Type": "application/json" },
-    body: payloadStr,
-    signal: AbortSignal.timeout(10000),
-  });
+
+  // Sentry performance span: measures GitHub API call duration for tracing
+  const res = await withSpan(
+    "GitHub: repository_dispatch",
+    "http.client",
+    {
+      "http.method": "POST",
+      "http.url": "https://api.github.com/repos/carloshmiranda/hive/dispatches",
+      "backlog.item_id": topItem.id,
+      "backlog.priority": topItem.priority,
+      "backlog.title": topItem.title.slice(0, 100),
+      "backlog.attempt": attemptCount + 1,
+    },
+    async (span) => {
+      const response = await fetch("https://api.github.com/repos/carloshmiranda/hive/dispatches", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${ghPat}`, Accept: "application/vnd.github.v3+json", "Content-Type": "application/json" },
+        body: payloadStr,
+        signal: AbortSignal.timeout(10000),
+      });
+      span?.setAttributes({ "http.status_code": response.status });
+      return response;
+    }
+  );
 
   if (res.ok || res.status === 204) {
     // Log the dispatch as an agent_action and capture its ID for tracing

--- a/src/lib/sentry-tags.ts
+++ b/src/lib/sentry-tags.ts
@@ -59,6 +59,27 @@ export function setSentryTags(options: SentryTagOptions) {
 }
 
 /**
+ * Wrap an async function in a Sentry performance span.
+ * Spans appear in Sentry's performance tab and provide duration breakdowns
+ * within a trace. Unlike breadcrumbs (which are chronological events),
+ * spans measure how long each operation takes.
+ *
+ * @param name - Human-readable span name shown in Sentry
+ * @param op - Operation category (ai.run, db.query, http.client, etc.)
+ * @param attributes - Static attributes known before execution
+ * @param fn - The async work to measure
+ * @returns The result of fn, with the span automatically finished
+ */
+export async function withSpan<T>(
+  name: string,
+  op: string,
+  attributes: Record<string, string | number | boolean>,
+  fn: (span: ReturnType<typeof Sentry.startInactiveSpan>) => Promise<T>
+): Promise<T> {
+  return Sentry.startSpan({ name, op, attributes }, (span) => fn(span));
+}
+
+/**
  * Extract action type from route path for consistent tagging
  */
 export function getActionTypeFromRoute(pathname: string): string {


### PR DESCRIPTION
## Summary

- Adds `withSpan()` helper to `sentry-tags.ts` — wraps any async operation in a Sentry performance span
- `ai.run` span around `callLLMWithTools` in `/api/agents/dispatch` — attributes: provider, model, duration_s, cost_usd, tool_call count (resolved at runtime after LLM responds)
- `http.client` span around the final GitHub `repository_dispatch` call in `/api/backlog/dispatch` — attributes: HTTP method/URL/status, backlog item ID, priority, attempt number

Spans complement the breadcrumbs added in #135 — breadcrumbs show the chronological event trail in error timelines, spans show duration waterfall in Sentry's Performance tab.

## Test plan

- [ ] TypeScript compiles clean (`npx tsc --noEmit --skipLibCheck`)
- [ ] CI passes
- [ ] Deploy to Vercel and trigger an agent dispatch — verify Sentry Performance tab shows `LLM: growth` span with provider/model attributes
- [ ] Trigger a backlog dispatch — verify `GitHub: repository_dispatch` span appears with HTTP status 204

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)