### PR TITLE
feat: OpenRouter account health check in Sentinel (every 6h)

### DIFF
--- a/src/app/api/cron/sentinel-dispatch/route.ts
+++ b/src/app/api/cron/sentinel-dispatch/route.ts
@@ -228,7 +228,7 @@ async function executeSentinelDispatch(request: Request) {
 
                 if (!existing) {
                   await sql`
-                    INSERT INTO approvals (gate_type, company_id, context, status, created_at, updated_at)
+                    INSERT INTO approvals (gate_type, company_id, context, status, created_at)
                     VALUES (
                       'spend_approval',
                       NULL,
@@ -240,7 +240,7 @@ async function executeSentinelDispatch(request: Request) {
                         message: `OpenRouter credits at ${Math.round(usagePct * 100)}% — top up to prevent agent failures`,
                       })},
                       'pending',
-                      NOW(), NOW()
+                      NOW()
                     )
                   `.catch((e: any) => console.warn("[sentinel-dispatch] Failed to create OR escalation:", e?.message));
                   dispatches.push({


### PR DESCRIPTION
## Summary

- Adds OpenRouter account health check to `sentinel-dispatch`, running every 6h
- Fetches `/api/v1/auth/key` to verify key validity and credit balance
- Logs: `free=bool, usage=N, limit=N|unlimited, pct=N%` for observability
- Creates a `spend_approval` gate when credits are >80% consumed on a limited plan (prevents agent failures from quota exhaustion)
- 401 response surfaces in logs as `OpenRouter API key invalid`
- Fully non-blocking — errors caught, never crashes Sentinel

Closes #144

## Test plan

- [ ] Sentinel runs without error with valid OR key
- [ ] `openrouter_health_check_at` is written to settings after first run
- [ ] Subsequent runs within 6h skip the check
- [ ] 401 key → warning logged, no crash
- [ ] Credits >80% on limited plan → `spend_approval` row created in approvals

🤖 Generated with [Claude Code](https://claude.com/claude-code)