### PR TITLE
feat: add concurrency groups to all agent workflows

### DIFF
--- a/.github/workflows/hive-ceo.yml
+++ b/.github/workflows/hive-ceo.yml
@@ -26,6 +26,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate CEO runs. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-ceo-${{ github.event.client_payload.company || 'portfolio' }}
+  cancel-in-progress: false
+
 jobs:
   ceo:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-decompose.yml
+++ b/.github/workflows/hive-decompose.yml
@@ -23,6 +23,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate Decompose runs per backlog item. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-decompose-${{ github.event.client_payload.backlog_id || github.event.inputs.backlog_id }}
+  cancel-in-progress: false
+
 jobs:
   decompose:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -31,6 +31,11 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+# Prevent duplicate Engineer runs per company. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-engineer-${{ github.event.client_payload.company || github.event.inputs.company || 'hive' }}
+  cancel-in-progress: false
+
 jobs:
   # ─── Resolve context for all jobs (non-secret outputs only) ───
   # NOTE: Tokens are NOT passed between jobs — GitHub Actions strips masked secrets from outputs.

--- a/.github/workflows/hive-evolver.yml
+++ b/.github/workflows/hive-evolver.yml
@@ -26,6 +26,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate Evolver runs. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-evolver
+  cancel-in-progress: false
+
 jobs:
   evolver:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-healer.yml
+++ b/.github/workflows/hive-healer.yml
@@ -21,6 +21,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate Healer runs per scope. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-healer-${{ github.event.client_payload.scope || github.event.inputs.scope || 'systemic' }}
+  cancel-in-progress: false
+
 jobs:
   healer:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-scout.yml
+++ b/.github/workflows/hive-scout.yml
@@ -28,6 +28,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate Scout runs. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-scout
+  cancel-in-progress: false
+
 jobs:
   scout:
     runs-on: ubuntu-latest

--- a/.github/workflows/hive-spec-gen.yml
+++ b/.github/workflows/hive-spec-gen.yml
@@ -24,6 +24,11 @@ permissions:
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+# Prevent duplicate Spec Gen runs per backlog item. cancel-in-progress: false queues rather than kills an in-progress run.
+concurrency:
+  group: hive-spec-${{ github.event.client_payload.backlog_id || github.event.inputs.backlog_id }}
+  cancel-in-progress: false
+
 jobs:
   spec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `concurrency:` blocks to all 7 agent workflow files to prevent duplicate runs
- Uses `cancel-in-progress: false` everywhere — queues new runs rather than killing in-progress ones (agent runs are expensive Claude API calls, not cheap CI builds)
- Groups are scoped to prevent unnecessary serialisation: CEO and Engineer allow parallel runs per different companies; Scout and Evolver are singletons; Healer groups by scope; Spec Gen and Decompose group by backlog item ID

Closes #134

## Test plan

- [ ] Trigger two CEO runs for the same company simultaneously — second should queue, not duplicate
- [ ] Trigger CEO runs for different companies simultaneously — both should run in parallel
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)