### PR TITLE
feat: auto-create GitHub releases with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # Uses conventional commits (feat:, fix:, chore:, etc.) to determine version bumps
+          # feat: → minor bump, fix: → patch bump, feat!:/fix!: → major bump
+          release-type: node
+          # Token with write access to create/update PRs and tags
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `release-please.yml` workflow that runs on every push to main
- Uses `googleapis/release-please-action@v4` to track conventional commits
- Creates a "Release PR" that bumps version in `package.json` and generates `CHANGELOG.md`
- When the Release PR is merged, automatically creates a GitHub release with tag

Version bump rules (conventional commits):
- `feat:` → minor version bump
- `fix:` → patch version bump  
- `feat!:` or `BREAKING CHANGE:` → major version bump
- `chore:`, `docs:`, `refactor:` → no release

No additional secrets required — uses built-in `GITHUB_TOKEN`.

Closes #125

## Test plan

- [ ] CI passes (just actionlint)
- [ ] After merge, release-please creates a "Release v1.0.0" PR automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)