### PR TITLE
[P2] Add Redis cache hit/miss metrics tracking

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,7 +1,7 @@
 import { getDb, json } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { decrypt } from "@/lib/crypto";
-import { cacheHealthCheck } from "@/lib/redis-cache";
+import { cacheHealthCheck, getCacheStats } from "@/lib/redis-cache";
 import { setSentryTags } from "@/lib/sentry-tags";
 
 export async function GET(request: Request) {
@@ -88,10 +88,13 @@ export async function GET(request: Request) {
   }
 
   // 4. Redis cache
-  const cacheStatus = await cacheHealthCheck();
+  const [cacheStatus, cacheStats] = await Promise.all([cacheHealthCheck(), getCacheStats()]);
+  const hitRatePct = cacheStats ? `${(cacheStats.hitRate * 100).toFixed(1)}% hit rate (${cacheStats.hits}/${cacheStats.total})` : null;
   checks.redis_cache = {
     status: cacheStatus.ok ? "ok" : "unavailable",
-    detail: cacheStatus.ok ? `${cacheStatus.latencyMs}ms latency` : "Not configured (KV_REST_API_URL/TOKEN missing)",
+    detail: cacheStatus.ok
+      ? [`${cacheStatus.latencyMs}ms latency`, hitRatePct].filter(Boolean).join(", ")
+      : "Not configured (KV_REST_API_URL/TOKEN missing)",
   };
 
   // 5. Secrets decryption — verify all encrypted settings are readable

--- a/src/lib/redis-cache.ts
+++ b/src/lib/redis-cache.ts
@@ -24,13 +24,55 @@ function getRedis(): Redis | null {
   return redis;
 }
 
+// --- Cache hit/miss metrics ---
+// Atomic counters in Redis — fire-and-forget increments (non-blocking, never break the hot path).
+// Keys never expire: they accumulate lifetime stats, readable via getCacheStats().
+
+const CACHE_HIT_KEY = "metrics:cache:hits";
+const CACHE_MISS_KEY = "metrics:cache:misses";
+
+export interface CacheStats {
+  hits: number;
+  misses: number;
+  total: number;
+  hitRate: number; // 0–1
+}
+
 // --- Generic cache helpers ---
 
 export async function cacheGet<T>(key: string): Promise<T | null> {
   try {
     const r = getRedis();
     if (!r) return null;
-    return await r.get<T>(key);
+    const value = await r.get<T>(key);
+    // Fire-and-forget hit/miss tracking — non-blocking, failure is non-fatal
+    if (value !== null && value !== undefined) {
+      r.incr(CACHE_HIT_KEY).catch(() => {});
+    } else {
+      r.incr(CACHE_MISS_KEY).catch(() => {});
+    }
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read lifetime cache hit/miss counters.
+ * Returns null if Redis is unavailable.
+ */
+export async function getCacheStats(): Promise<CacheStats | null> {
+  try {
+    const r = getRedis();
+    if (!r) return null;
+    const [rawHits, rawMisses] = await r.mget<[number | null, number | null]>(
+      CACHE_HIT_KEY,
+      CACHE_MISS_KEY,
+    );
+    const hits = rawHits ?? 0;
+    const misses = rawMisses ?? 0;
+    const total = hits + misses;
+    return { hits, misses, total, hitRate: total > 0 ? hits / total : 0 };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Adds atomic hit/miss counters to `cacheGet()` via Redis INCR (fire-and-forget, non-blocking)
- Exports `getCacheStats()` from `redis-cache.ts` — reads `metrics:cache:hits` and `metrics:cache:misses` with `mget`
- Surfaces hit rate in `/api/health` redis_cache check: e.g. `"12ms latency, 73.2% hit rate (1463/1999)"`

## Design notes

- Counters accumulate lifetime (never expire) — gives long-term cache efficiency signal
- Fire-and-forget: `r.incr(...).catch(() => {})` — zero latency impact on cache reads
- `enableAutoPipelining: true` on the Redis client means concurrent INCRs batch automatically
- Hit rate shows up immediately in the existing `/api/health` response, no new endpoint needed

## Test plan

- [x] Build passes: `npm run build` — clean
- [ ] Deploy and check `/api/health` response includes `hit rate` after a few cached requests
- [ ] Verify counters increment correctly after cache hit vs. miss

Closes #133