### PR TITLE
feat: job summaries for all brain agent workflows

### DIFF
--- a/.github/workflows/hive-ceo.yml
+++ b/.github/workflows/hive-ceo.yml
@@ -153,3 +153,23 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
         run: npx tsx scripts/chain-dispatch.ts
+
+      - name: Job summary
+        if: always()
+        env:
+          TRIGGER: ${{ steps.context.outputs.trigger }}
+          COMPANY: ${{ github.event.client_payload.company || 'portfolio' }}
+          AGENT_OUTCOME: ${{ steps.agent.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STATUS_ICON="${{ steps.agent.outcome == 'success' && '✅' || '❌' }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # ${STATUS_ICON} CEO — ${TRIGGER} (${COMPANY})
+
+          | Field | Value |
+          |-------|-------|
+          | Trigger | \`${TRIGGER}\` |
+          | Company | \`${COMPANY}\` |
+          | Outcome | ${AGENT_OUTCOME} |
+          | Run | [View logs](${RUN_URL}) |
+          EOF

--- a/.github/workflows/hive-engineer.yml
+++ b/.github/workflows/hive-engineer.yml
@@ -1348,3 +1348,21 @@ jobs:
               -H "Content-Type: application/json" \
               -d "{\"agent\":\"engineer\",\"action\":\"feature_request\",\"company\":\"${{ needs.context.outputs.company }}\",\"status\":\"failed\",\"summary\":\"${SUBTYPE} after ${TURNS} turns\",\"error\":\"${ERROR_ESCAPED:0:200}\",\"run_url\":\"$RUN_URL\",\"task_title\":\"${TASK_ESCAPED:0:100}\",\"duration_s\":$((TURNS * 60))}" || true
           fi
+
+          # Job summary
+          STATUS_ICON="✅"
+          [ "$LOG_STATUS" = "failed" ] && STATUS_ICON="❌"
+          [ "$LOG_STATUS" = "skipped" ] && STATUS_ICON="⏭️"
+          COMPANY="${{ needs.context.outputs.company }}"
+          TASK_SHORT="${TASK_ESCAPED:0:120}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # ${STATUS_ICON} Engineer — ${SUBTYPE} (${COMPANY})
+
+          | Field | Value |
+          |-------|-------|
+          | Task | ${TASK_SHORT} |
+          | Subtype | \`${SUBTYPE}\` |
+          | Company | \`${COMPANY}\` |
+          | Outcome | ${LOG_STATUS} (${TURNS} turns) |
+          | Run | [View logs](${RUN_URL}) |
+          EOF

--- a/.github/workflows/hive-evolver.yml
+++ b/.github/workflows/hive-evolver.yml
@@ -121,3 +121,20 @@ jobs:
             - If prompt evolution is needed, store new version in agent_prompts (is_active = false).
 
       # Evolver is a terminal node — no chain dispatch needed.
+
+      - name: Job summary
+        if: always()
+        env:
+          AGENT_OUTCOME: ${{ steps.agent.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STATUS_ICON="${{ steps.agent.outcome == 'success' && '✅' || '❌' }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # ${STATUS_ICON} Evolver
+
+          | Field | Value |
+          |-------|-------|
+          | Trigger | scheduled |
+          | Outcome | ${AGENT_OUTCOME} |
+          | Run | [View logs](${RUN_URL}) |
+          EOF

--- a/.github/workflows/hive-healer.yml
+++ b/.github/workflows/hive-healer.yml
@@ -288,3 +288,21 @@ jobs:
           trigger: error_fix
           execution_file: ${{ steps.agent.outputs.execution_file }}
           cron_secret: ${{ secrets.CRON_SECRET }}
+
+      - name: Job summary
+        if: always()
+        env:
+          SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || 'systemic' }}
+          AGENT_OUTCOME: ${{ steps.agent.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STATUS_ICON="${{ steps.agent.outcome == 'success' && '✅' || '❌' }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # ${STATUS_ICON} Healer — ${SCOPE}
+
+          | Field | Value |
+          |-------|-------|
+          | Scope | \`${SCOPE}\` |
+          | Outcome | ${AGENT_OUTCOME} |
+          | Run | [View logs](${RUN_URL}) |
+          EOF

--- a/.github/workflows/hive-scout.yml
+++ b/.github/workflows/hive-scout.yml
@@ -240,3 +240,23 @@ jobs:
           fi
 
           echo "Chain dispatch complete"
+
+      - name: Job summary
+        if: always()
+        env:
+          TRIGGER: ${{ steps.context.outputs.trigger }}
+          COMPANY: ${{ github.event.client_payload.company || steps.context.outputs.company || 'pipeline' }}
+          AGENT_OUTCOME: ${{ steps.agent.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          STATUS_ICON="${{ steps.agent.outcome == 'success' && '✅' || '❌' }}"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # ${STATUS_ICON} Scout — ${TRIGGER} (${COMPANY})
+
+          | Field | Value |
+          |-------|-------|
+          | Trigger | \`${TRIGGER}\` |
+          | Company | \`${COMPANY}\` |
+          | Outcome | ${AGENT_OUTCOME} |
+          | Run | [View logs](${RUN_URL}) |
+          EOF


### PR DESCRIPTION
## Summary
- Adds `Job summary` step to CEO, Scout, Engineer, Evolver, and Healer workflows
- Each step appends a markdown table to `$GITHUB_STEP_SUMMARY` with trigger, company/scope, outcome, and run link
- Visible in GitHub Actions UI without opening individual logs
- Uses `if: always()` so summary appears even on failure

## Test plan
- [ ] CI passes (YAML-only change — no TypeScript to validate)
- [ ] Each workflow's last step is the job summary

Closes backlog item `535ec38a` — job summaries for brain agent workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)