### PR TITLE
feat: Sentry breadcrumbs for dispatch chain routes

### DIFF
--- a/src/app/api/agents/consolidate/route.ts
+++ b/src/app/api/agents/consolidate/route.ts
@@ -1,6 +1,7 @@
 import { getDb, json, err } from "@/lib/db";
 import { dispatchEvent } from "@/lib/dispatch";
 import { invalidatePlaybook } from "@/lib/redis-cache";
+import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,8 @@ export async function POST(req: Request) {
   if (!company_slug && !cycle_id) {
     return err("Missing company_slug or cycle_id", 400);
   }
+
+  setSentryTags({ agent: "sentinel", action_type: "cycle_consolidation", route: "/api/agents/consolidate" });
 
   const sql = getDb();
   const results = {
@@ -70,6 +73,12 @@ export async function POST(req: Request) {
   const reviewData = review.review || review;
   const score = reviewData.score;
   results.cycle_score = score;
+
+  addDispatchBreadcrumb({
+    category: "dispatch",
+    message: "Consolidating cycle",
+    data: { company: cycle.slug, cycle_number: cycle.cycle_number, score },
+  });
 
   // --- 1. Extract and write playbook entry from CEO review ---
   const entry = reviewData.playbook_entry;
@@ -145,6 +154,11 @@ export async function POST(req: Request) {
   // Invalidate playbook cache after any new entries or confidence changes
   if (results.playbook_entries_created > 0) {
     await invalidatePlaybook();
+    addDispatchBreadcrumb({
+      category: "db",
+      message: "Playbook entries written",
+      data: { count: results.playbook_entries_created, company: cycle.slug },
+    });
   }
 
   // --- 2 & 3. Confidence boost/decay based on cycle score ---
@@ -259,6 +273,11 @@ export async function POST(req: Request) {
           patterns: autoFixablePatterns,
         });
         results.healer_dispatched = true;
+        addDispatchBreadcrumb({
+          category: "dispatch",
+          message: "Healer dispatched from consolidation",
+          data: { critical_patterns: criticalHighCount, company: cycle.slug },
+        });
       } catch (e) {
         console.warn(`[consolidate] Healer dispatch failed: ${e instanceof Error ? e.message : "unknown"}`);
       }

--- a/src/app/api/dispatch/cycle-complete/route.ts
+++ b/src/app/api/dispatch/cycle-complete/route.ts
@@ -2,6 +2,7 @@ import { getDb, json } from "@/lib/db";
 import { getGitHubToken } from "@/lib/github-app";
 import { invalidateCompanyCache } from "@/lib/cache";
 import { qstashPublish } from "@/lib/qstash";
+import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
 
 const REPO = "carloshmiranda/hive";
 const HIVE_URL = process.env.NEXT_PUBLIC_URL || "https://hive-phi.vercel.app";
@@ -88,6 +89,13 @@ export async function POST(req: Request) {
   const { agent, company, status, action_type } = body;
   const callbackStatus = status === "failed" ? "failed" : "success";
 
+  setSentryTags({ agent: agent || "dispatch", action_type: action_type || "cycle_callback", route: "/api/dispatch/cycle-complete" });
+  addDispatchBreadcrumb({
+    category: "dispatch",
+    message: "Cycle complete callback received",
+    data: { agent, company, status: callbackStatus },
+  });
+
   // Log the completion (skip for chain retries)
   if (agent && company && agent !== "chain_retry") {
     const [companyRecord] = await sql`
@@ -171,6 +179,12 @@ export async function POST(req: Request) {
 
   const healthRaw = await healthRes.json();
   const health = healthRaw.data || healthRaw;
+
+  addDispatchBreadcrumb({
+    category: "dispatch",
+    message: "Health gate checked",
+    data: { recommendation: health.recommendation, claude_pct: health.budget?.claude_pct },
+  });
 
   if (health.recommendation === "stop") {
     // Claude is blocked — dispatch free workers and retry when budget resets
@@ -349,6 +363,11 @@ export async function POST(req: Request) {
   }
 
   if (dispatched.length > 0) {
+    addDispatchBreadcrumb({
+      category: "dispatch",
+      message: "Chaining to next companies",
+      data: { count: dispatched.length, slugs: dispatched.map(d => d.slug), completed_company: company },
+    });
     const summary = dispatched.map(d => `${d.slug} (${d.priority_score})`).join(", ");
     await qstashPublish("/api/notify", {
       agent: "dispatch",

--- a/src/app/api/dispatch/qstash-failure/route.ts
+++ b/src/app/api/dispatch/qstash-failure/route.ts
@@ -1,6 +1,7 @@
 import { json, err, getDb } from "@/lib/db";
 import { verifyCronAuth } from "@/lib/qstash";
 import { qstashPublish } from "@/lib/qstash";
+import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
 
 // POST /api/dispatch/qstash-failure — QStash failure callback endpoint
 // Called by QStash when all delivery retries for a message are exhausted.
@@ -54,6 +55,13 @@ export async function POST(req: Request) {
   ]
     .filter(Boolean)
     .join(", ");
+
+  setSentryTags({ agent: "dispatch", action_type: "qstash_failure", route: "/api/dispatch/qstash-failure" });
+  addDispatchBreadcrumb({
+    category: "qstash",
+    message: "Dead dispatch — all retries exhausted",
+    data: { targetPath, responseStatus, retried, maxRetries, sourceMessageId },
+  });
 
   console.error(`[qstash-failure] Dead dispatch detected — ${errorDetail}`);
 

--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { json, err } from "@/lib/db";
 import { notifyHive } from "@/lib/telegram";
+import { setSentryTags, addDispatchBreadcrumb } from "@/lib/sentry-tags";
 
 // POST /api/notify — send a Telegram notification
 // Auth: CRON_SECRET or OIDC
@@ -28,6 +29,13 @@ export async function POST(req: NextRequest) {
   if (!agent || !action || !status || !summary) {
     return err("Missing required fields: agent, action, status, summary", 400);
   }
+
+  setSentryTags({ agent, action_type: action, route: "/api/notify" });
+  addDispatchBreadcrumb({
+    category: "dispatch",
+    message: "Hive notification",
+    data: { agent, action, company, status },
+  });
 
   // Accept any status — agents use various statuses (dispatched, needs_carlos, etc.)
   // Normalize to the closest valid NotificationEvent status for formatting


### PR DESCRIPTION
## Summary
- Adds `setSentryTags` + `addDispatchBreadcrumb` to 4 dispatch chain routes that lacked Sentry coverage
- `/api/agents/consolidate` — tags for cycle_consolidation, breadcrumbs on cycle start, playbook writes, healer dispatch
- `/api/dispatch/cycle-complete` — breadcrumbs on callback received, health gate check, chain dispatch decisions
- `/api/dispatch/qstash-failure` — breadcrumb for dead dispatch (all retries exhausted)
- `/api/notify` — breadcrumb for every Hive notification sent

Closes backlog item `4ef5d3ba`: Add Sentry breadcrumbs to dispatch chain

## Test plan
- [ ] TypeScript check passes (verified: `tsc --noEmit` clean)
- [ ] CI lint-and-build passes
- [ ] No behaviour changes — breadcrumbs are fire-and-forget, non-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)