### PR TITLE
feat: web search reads from settings + Tavily fallback (#75)

### DIFF
--- a/src/app/api/agents/tools/route.ts
+++ b/src/app/api/agents/tools/route.ts
@@ -3,6 +3,7 @@ import { getDb, json, err } from "@/lib/db";
 import { type HiveToolCall, type HiveToolResult } from "@/lib/hive-tools";
 import { setSentryTags } from "@/lib/sentry-tags";
 import { getStripeForCompany, getStripeAgentTools } from "@/lib/stripe";
+import { webSearch as executeWebSearch } from "@/lib/web-search";
 
 // Tool execution endpoint for Hive API functions
 // Called by agents via tool calling to query/update the Hive database
@@ -459,40 +460,5 @@ async function getStripeTools(sql: any, args: { company: string }): Promise<any>
 
 async function webSearch(args: { query: string; count?: number }): Promise<any> {
   const { query, count = 5 } = args;
-
-  const apiKey = process.env.BRAVE_SEARCH_API_KEY;
-  if (!apiKey) {
-    return { results: [], warning: "Web search not configured (missing BRAVE_SEARCH_API_KEY)" };
-  }
-
-  const safeCount = Math.min(Math.max(1, count), 10);
-  const searchUrl = new URL("https://api.search.brave.com/res/v1/web/search");
-  searchUrl.searchParams.set("q", query.trim());
-  searchUrl.searchParams.set("count", String(safeCount));
-  searchUrl.searchParams.set("text_decorations", "false");
-  searchUrl.searchParams.set("search_lang", "en");
-
-  const res = await fetch(searchUrl.toString(), {
-    headers: {
-      Accept: "application/json",
-      "Accept-Encoding": "gzip",
-      "X-Subscription-Token": apiKey,
-    },
-  });
-
-  if (!res.ok) {
-    throw new Error(`Brave Search API returned ${res.status}`);
-  }
-
-  const data = await res.json();
-  const webResults = data?.web?.results ?? [];
-
-  return {
-    results: webResults.slice(0, safeCount).map((r: any) => ({
-      title: r.title ?? "",
-      url: r.url ?? "",
-      snippet: r.description ?? "",
-    })),
-    query,
-  };
+  return executeWebSearch(query, count);
 }

--- a/src/app/api/agents/web-search/route.ts
+++ b/src/app/api/agents/web-search/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest } from "next/server";
 import { json, err } from "@/lib/db";
+import { webSearch } from "@/lib/web-search";
 
 // POST /api/agents/web-search — web search for worker agents (CRON_SECRET auth)
 // Body: { query: string, count?: number }
-// Returns: { results: Array<{ title, url, snippet }> }
+// Returns: { results: Array<{ title, url, snippet }>, provider?, warning? }
 export async function POST(req: NextRequest) {
   const auth = req.headers.get("authorization");
   if (!auth || auth !== `Bearer ${process.env.CRON_SECRET}`) {
@@ -22,46 +23,6 @@ export async function POST(req: NextRequest) {
     return err("query is required", 400);
   }
 
-  const apiKey = process.env.BRAVE_SEARCH_API_KEY;
-  if (!apiKey) {
-    console.warn("[web-search] BRAVE_SEARCH_API_KEY not set — returning empty results");
-    return json({ results: [], warning: "Web search not configured (missing BRAVE_SEARCH_API_KEY)" });
-  }
-
-  try {
-    const safeCount = Math.min(Math.max(1, count), 10);
-    const searchUrl = new URL("https://api.search.brave.com/res/v1/web/search");
-    searchUrl.searchParams.set("q", query.trim());
-    searchUrl.searchParams.set("count", String(safeCount));
-    searchUrl.searchParams.set("text_decorations", "false");
-    searchUrl.searchParams.set("search_lang", "en");
-
-    const res = await fetch(searchUrl.toString(), {
-      headers: {
-        Accept: "application/json",
-        "Accept-Encoding": "gzip",
-        "X-Subscription-Token": apiKey,
-      },
-    });
-
-    if (!res.ok) {
-      const errText = await res.text().catch(() => "");
-      console.error(`[web-search] Brave API error ${res.status}: ${errText}`);
-      return json({ results: [], error: `Search API returned ${res.status}` });
-    }
-
-    const data = await res.json();
-    const webResults = data?.web?.results ?? [];
-
-    const results = webResults.slice(0, safeCount).map((r: any) => ({
-      title: r.title ?? "",
-      url: r.url ?? "",
-      snippet: r.description ?? "",
-    }));
-
-    return json({ results });
-  } catch (e: any) {
-    console.error(`[web-search] Error: ${e?.message}`);
-    return json({ results: [], error: e?.message ?? "Search failed" });
-  }
+  const result = await webSearch(query, count);
+  return json(result);
 }

--- a/src/app/api/connectivity/test/route.ts
+++ b/src/app/api/connectivity/test/route.ts
@@ -138,6 +138,33 @@ async function runConnectivityTest(servicesToTest: string[] = ['all']) {
     });
   }
 
+  // Test web search provider (Brave or Tavily)
+  if (servicesToTest.includes('all') || servicesToTest.includes('web_search')) {
+    await testWithLatency('web_search', async () => {
+      const braveKey = await getSettingValue("brave_api_key");
+      const tavilyKey = await getSettingValue("tavily_api_key");
+
+      if (braveKey) {
+        const res = await fetch("https://api.search.brave.com/res/v1/web/search?q=test&count=1", {
+          headers: {
+            Accept: "application/json",
+            "X-Subscription-Token": braveKey,
+          },
+        });
+        if (!res.ok) throw new Error(`Brave Search API returned ${res.status}`);
+      } else if (tavilyKey) {
+        const res = await fetch("https://api.tavily.com/search", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ api_key: tavilyKey, query: "test", max_results: 1 }),
+        });
+        if (!res.ok) throw new Error(`Tavily API returned ${res.status}`);
+      } else {
+        throw new Error("Web search not configured (set brave_api_key or tavily_api_key in Settings)");
+      }
+    });
+  }
+
   // Overall status
   const statuses = Object.values(results).map(r => r.status);
   const overall = statuses.includes('error') ? 'failed' : 'passed';

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -1,0 +1,127 @@
+import { getSettingValue } from "./settings";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  provider?: string;
+  query?: string;
+  warning?: string;
+  error?: string;
+}
+
+/**
+ * Resolve the active web search provider and API key.
+ * Priority: settings table > environment variables.
+ * Supports Brave Search and Tavily.
+ */
+async function resolveSearchProvider(): Promise<{ provider: "brave" | "tavily"; key: string } | null> {
+  // Brave — settings first, then env
+  const braveKey =
+    (await getSettingValue("brave_api_key")) ||
+    process.env.BRAVE_SEARCH_API_KEY ||
+    null;
+  if (braveKey) return { provider: "brave", key: braveKey };
+
+  // Tavily — settings first, then env
+  const tavilyKey =
+    (await getSettingValue("tavily_api_key")) ||
+    process.env.TAVILY_API_KEY ||
+    null;
+  if (tavilyKey) return { provider: "tavily", key: tavilyKey };
+
+  return null;
+}
+
+async function searchBrave(key: string, query: string, count: number): Promise<SearchResult[]> {
+  const url = new URL("https://api.search.brave.com/res/v1/web/search");
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(count));
+  url.searchParams.set("text_decorations", "false");
+  url.searchParams.set("search_lang", "en");
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      "Accept-Encoding": "gzip",
+      "X-Subscription-Token": key,
+    },
+  });
+
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(`Brave Search API returned ${res.status}: ${msg}`);
+  }
+
+  const data = await res.json();
+  return (data?.web?.results ?? []).slice(0, count).map((r: any) => ({
+    title: r.title ?? "",
+    url: r.url ?? "",
+    snippet: r.description ?? "",
+  }));
+}
+
+async function searchTavily(key: string, query: string, count: number): Promise<SearchResult[]> {
+  const res = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: key,
+      query,
+      max_results: count,
+      search_depth: "basic",
+      include_answer: false,
+      include_raw_content: false,
+    }),
+  });
+
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(`Tavily API returned ${res.status}: ${msg}`);
+  }
+
+  const data = await res.json();
+  return (data?.results ?? []).slice(0, count).map((r: any) => ({
+    title: r.title ?? "",
+    url: r.url ?? "",
+    snippet: r.content ?? "",
+  }));
+}
+
+/**
+ * Execute a web search using the configured provider.
+ * Falls back gracefully if no provider is configured.
+ */
+export async function webSearch(query: string, count = 5): Promise<SearchResponse> {
+  const safeCount = Math.min(Math.max(1, count), 10);
+  const q = query.trim();
+
+  const provider = await resolveSearchProvider();
+
+  if (!provider) {
+    console.warn("[web-search] No provider configured (set brave_api_key or tavily_api_key in settings)");
+    return {
+      results: [],
+      warning: "Web search not configured — add brave_api_key or tavily_api_key in Settings",
+    };
+  }
+
+  try {
+    const results =
+      provider.provider === "brave"
+        ? await searchBrave(provider.key, q, safeCount)
+        : await searchTavily(provider.key, q, safeCount);
+
+    console.log(`[web-search] ${provider.provider}: "${q}" → ${results.length} results`);
+    return { results, provider: provider.provider, query: q };
+  } catch (e: any) {
+    console.error(`[web-search] ${provider.provider} error: ${e.message}`);
+    return { results: [], provider: provider.provider, error: e.message };
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts shared `webSearch()` utility to `src/lib/web-search.ts`
- Key resolution priority: settings table (`brave_api_key` / `tavily_api_key`) → env var fallback
- Adds Tavily as a second provider — used automatically when Brave not configured
- Both `/api/agents/web-search` and `/api/agents/tools` now use the shared util
- Connectivity test (`/api/connectivity/test`) checks web search provider health

Closes #75

## Test plan
- [ ] Set `brave_api_key` in Settings → web search uses Brave
- [ ] Remove `brave_api_key`, set `tavily_api_key` → web search uses Tavily
- [ ] Neither configured → graceful "not configured" warning (no crash)
- [ ] Connectivity test shows `web_search: ok` when key is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)