### PR TITLE
fix: dashboard crash on session expiry (JSON parse on HTML response)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,8 +174,10 @@ export default function DashboardPage() {
   const [neonUsage, setNeonUsage] = useState<NeonUsage | null>(null);
 
   const fetchAll = useCallback(async () => {
+    try {
     const res = await fetch("/api/dashboard");
     if (!res.ok) return;
+    if (!res.headers.get("content-type")?.includes("application/json")) return;
     const { data } = await res.json();
     setPortfolio(data.portfolio);
     setCompanies(data.companies);
@@ -192,6 +194,7 @@ export default function DashboardPage() {
       const todoRes = await fetch("/api/todos");
       if (todoRes.ok) setTodos((await todoRes.json()).data || []);
     } catch { /* non-critical */ }
+    } catch { /* session expired or network error — stay on loading state */ }
   }, []);
 
   // Neon usage: fetched once on load (calls external Neon API — no need to poll every 2m)


### PR DESCRIPTION
## Summary
- When session expires, `/api/dashboard` returns 307→`/login` which resolves to 200 HTML
- `res.ok` was `true` so `res.json()` was called on HTML, throwing `SyntaxError: Unexpected token '<'`
- This unhandled exception bubbled up to the Next.js global error boundary ("Something went wrong")

## Fix
- Added `Content-Type` header check before calling `res.json()`
- Wrapped entire `fetchAll` in try-catch to absorb any remaining parse/network errors silently

## Test plan
- [ ] Verify dashboard loads normally when logged in
- [ ] Verify dashboard stays on loading state (no crash) when session expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)