### PR TITLE
feat: learning rate kill signal

### DIFF
--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
-import { computeValidationScore, checkCEOScoreKillTrigger } from '@/lib/validation';
+import { computeValidationScore, checkCEOScoreKillTrigger, checkLearningRateKillTrigger } from '@/lib/validation';
 import type { MetricsRow } from '@/lib/validation';
 
 // ─── Arbitraries ───
@@ -227,5 +227,89 @@ describe('checkCEOScoreKillTrigger', () => {
       ),
       { numRuns: 200 }
     );
+  });
+});
+
+// ─── checkLearningRateKillTrigger tests ───
+
+describe('checkLearningRateKillTrigger', () => {
+  it('returns null when fewer than 4 cycles provided', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            cycle_number: fc.nat({ max: 100 }),
+            score: fc.double({ min: 0, max: 10, noNaN: true }).map(String),
+          }),
+          { minLength: 0, maxLength: 3 }
+        ),
+        (cycles) => {
+          expect(checkLearningRateKillTrigger(cycles)).toBeNull();
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('returns a trigger message when avg < 6 and range < 1.5 across 4+ cycles', () => {
+    // All scores tightly clustered around 4 (avg 4, range 0) — clearly stagnant
+    const stagnantCycles = [
+      { cycle_number: 1, score: '4.0' },
+      { cycle_number: 2, score: '4.1' },
+      { cycle_number: 3, score: '3.9' },
+      { cycle_number: 4, score: '4.0' },
+    ];
+    const result = checkLearningRateKillTrigger(stagnantCycles);
+    expect(result).not.toBeNull();
+    expect(result).toContain('LEARNING RATE STAGNANT');
+  });
+
+  it('returns null when avg >= 6 even if range is small', () => {
+    fc.assert(
+      fc.property(
+        // Generate 4+ cycles all with scores between 6 and 7 (avg >= 6, range < 1.5)
+        fc.array(
+          fc.record({
+            cycle_number: fc.nat({ max: 100 }),
+            score: fc.double({ min: 6, max: 7, noNaN: true }).map(String),
+          }),
+          { minLength: 4, maxLength: 8 }
+        ),
+        (cycles) => {
+          expect(checkLearningRateKillTrigger(cycles)).toBeNull();
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('returns null when avg < 6 but range >= 1.5 (improvement signal present)', () => {
+    // Scores vary widely (e.g. 2 to 8) — range is large enough to show learning
+    const improvingCycles = [
+      { cycle_number: 1, score: '2.0' },
+      { cycle_number: 2, score: '3.5' },
+      { cycle_number: 3, score: '5.0' },
+      { cycle_number: 4, score: '7.0' },
+    ];
+    expect(checkLearningRateKillTrigger(improvingCycles)).toBeNull();
+  });
+
+  it('uses only the 6 most recent cycles by cycle_number', () => {
+    // Older cycles are bad (stagnant), recent cycles are improving
+    const cycles = [
+      { cycle_number: 1, score: '3.0' },
+      { cycle_number: 2, score: '3.1' },
+      { cycle_number: 3, score: '2.9' },
+      { cycle_number: 4, score: '3.0' },
+      // Recent cycles (used): high variance, so no trigger
+      { cycle_number: 10, score: '2.0' },
+      { cycle_number: 11, score: '5.0' },
+      { cycle_number: 12, score: '3.0' },
+      { cycle_number: 13, score: '7.0' },
+      { cycle_number: 14, score: '2.0' },
+      { cycle_number: 15, score: '6.5' },
+    ];
+    // The 6 most recent: cycles 10-15 → range ~5 → no trigger
+    expect(checkLearningRateKillTrigger(cycles)).toBeNull();
   });
 });

--- a/src/app/api/agents/context/route.ts
+++ b/src/app/api/agents/context/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { validateOIDC } from "@/lib/oidc";
 import { getDb, json, err } from "@/lib/db";
-import { computeValidationScore, normalizeBusinessType, checkCEOScoreKillTrigger } from "@/lib/validation";
+import { computeValidationScore, normalizeBusinessType, checkCEOScoreKillTrigger, checkLearningRateKillTrigger } from "@/lib/validation";
 import { getCapabilitySummary } from "@/lib/hive-capabilities";
 import { checkForbidden } from "@/lib/phase-gate";
 import { normalizeError, errorSimilarity } from "@/lib/error-normalize";
@@ -778,15 +778,20 @@ async function ceoContext(sql: any, company: any) {
   ).catch(() => false);
 
   // Check for CEO score kill evaluation trigger
-  const ceoScoreKillTrigger = checkCEOScoreKillTrigger(recentCycles.map((c: { cycle_number: number; score: string }) => ({
+  const cyclesMapped = recentCycles.map((c: { cycle_number: number; score: string }) => ({
     cycle_number: c.cycle_number,
     score: c.score
-  })));
+  }));
+  const ceoScoreKillTrigger = checkCEOScoreKillTrigger(cyclesMapped);
+  const learningRateKillTrigger = checkLearningRateKillTrigger(cyclesMapped);
 
   // Combine all kill evaluation triggers
   const allKillEvaluationTriggers = [...validation.kill_evaluation_triggers];
   if (ceoScoreKillTrigger) {
     allKillEvaluationTriggers.push(ceoScoreKillTrigger);
+  }
+  if (learningRateKillTrigger) {
+    allKillEvaluationTriggers.push(learningRateKillTrigger);
   }
 
   return {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -564,6 +564,31 @@ export function checkCEOScoreKillTrigger(recentCycles: Array<{ cycle_number: num
   return null;
 }
 
+export function checkLearningRateKillTrigger(
+  recentCycles: Array<{ cycle_number: number; score: string }>
+): string | null {
+  if (recentCycles.length < 4) return null;
+
+  const sorted = [...recentCycles]
+    .sort((a, b) => b.cycle_number - a.cycle_number)
+    .slice(0, 6);
+
+  const scores = sorted
+    .map(c => { const s = parseFloat(c.score); return isNaN(s) ? null : s; })
+    .filter((s): s is number => s !== null);
+
+  if (scores.length < 4) return null;
+
+  const avg = scores.reduce((sum, v) => sum + v, 0) / scores.length;
+  const range = Math.max(...scores) - Math.min(...scores);
+
+  if (avg < 6 && range < 1.5) {
+    return `LEARNING RATE STAGNANT: ${scores.length} cycles with CEO scores ${scores.map(s => s.toFixed(1)).join('→')} (avg ${avg.toFixed(1)}/10, no improvement detected)`;
+  }
+
+  return null;
+}
+
 // ─── Main function ───
 
 export function computeValidationScore(


### PR DESCRIPTION
## Summary

- Adds `checkLearningRateKillTrigger()` to `validation.ts` — fires when the last 4-6 CEO scores are low (avg < 6/10) AND flat (range < 1.5), indicating stagnation despite continued activity
- Wired in `/api/agents/context` alongside `checkCEOScoreKillTrigger` — result merged into `kill_evaluation_triggers` sent to CEO
- 5 new property-based tests (fast-check) covering: insufficient data, stagnant trigger, good avg, high range (improving), and window windowing to 6 most recent cycles

## Test plan

- [x] `npm test` — 17 tests pass (12 existing + 5 new)
- [ ] Verify context route returns `kill_evaluation_triggers` with stagnation message for a company with flat low scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)