### PR TITLE
feat: post-merge health check (Check 42)

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -15,6 +15,20 @@
 
 ---
 
+### 2026-04-03 Interactive session PR merges bypass syncIssueForBacklog — GitHub issues left open
+**What happened:** PRs merged via `gh pr merge --admin` in Claude Code sessions leave GitHub issues open. Issues #109 and #118 remained open after their PRs (#370, #371) were merged days earlier.
+**Root cause:** `reviewAndMergeOpenPRs()` in `dispatch/route.ts` is the only place that calls `syncIssueForBacklog`. It also sets `pr_number` on backlog items. When PRs are merged interactively (not via the dispatch route), `pr_number` stays `null` and the issue sync never runs. The dispatch route's `WHERE pr_number = $1` query then can't find those items even if it runs later.
+**Fix applied:** Manually closed issues with `gh issue close <N> --comment "..."`. Two-part fix needed: (1) MISTAKES.md entry so this isn't missed again, (2) post-merge health check (backlog item `6b4cc45a`) to detect regressions quickly.
+**Prevention:** After every `gh pr merge --admin` in an interactive session, immediately run: `gh issue close <N> --comment "Resolved by PR #<M>"` for each linked GitHub issue. Check `hive_backlog WHERE status='done' AND github_issue_number IS NOT NULL AND pr_number IS NULL` to find any items that slipped through.
+**Affects:** hive
+
+### 2026-04-03 Direct push to main bypassed CI required status checks
+**What happened:** Committed `.githooks/pre-commit` and `package.json` changes directly to `main` instead of using a feature branch + PR. GitHub showed "Bypassed rule violations for refs/heads/main: Required status check CI / lint-and-build is expected."
+**Root cause:** Treating a small chore commit as not needing CI review. Branch protection rules exist for all commits to main regardless of size.
+**Fix applied:** Created `hive/improvement/learning-rate-kill-signal` branch for subsequent work. All code changes went through branch → commit → push → PR.
+**Prevention:** ALWAYS branch first, even for 1-line changes. Never push to `main` directly. The correct flow is: `git checkout -b hive/improvement/<slug>` → commit → `git push origin <branch>` → `gh pr create`.
+**Affects:** hive
+
 ### 2026-04-02 Sentry had zero client-side coverage despite being "installed"
 **What happened:** `@sentry/nextjs` was installed, `sentry.server.config.ts` existed, but `instrumentation.ts` and `instrumentation-client.ts` were never created. Result: zero browser error tracking, no Session Replay, server errors only partially captured.
 **Root cause:** The old Sentry setup pattern used `sentry.client.config.ts` (deprecated). Modern `@sentry/nextjs` ≥8 requires `instrumentation-client.ts` for client-side init and `instrumentation.ts` (with `register()` + `onRequestError`) for server/edge. The wizard would have created both, but the initial setup was manual/partial.
@@ -47,6 +61,24 @@
 **Root cause:** The agent was named `backlog` at code-time, but the DB schema's `agent_actions.agent` CHECK enumerates specific values. `backlog` was never in the allowed list; `backlog_dispatch` is.
 **Fix applied:** Replaced all 4 occurrences of `'backlog'` with `'backlog_dispatch'` in the INSERT statements.
 **Prevention:** When inserting into `agent_actions`, always check the agent CHECK constraint in `schema.sql` or `schema-map.ts`. The lint-sql script catches violations pre-merge.
+**Affects:** hive
+
+---
+
+### 2026-04-02 LEFT JOIN returns a row even when the right table has no matching rows
+**What happened:** `/api/metrics/unit-economics` was checking `rows.length === 0` to detect a company-not-found condition. A valid company_id with zero metric rows still produces one row from the LEFT JOIN (with all metric columns NULL and `resolved_id` non-null). The check passed and the handler tried to read `rows[0].company_created_at`, returning garbage data instead of a 404.
+**Root cause:** LEFT JOIN semantics — the query `FROM companies LEFT JOIN metrics ON ...` always emits at least one row per company (with NULLs for the right side when no metrics exist). The original check only tested array length, not whether the company itself was found.
+**Fix applied:** Added a second guard: `if (rows.length === 0 || rows[0].resolved_id === null) return err("Company not found", 404);` The `resolved_id` column is `c.id` aliased in the SELECT, which is always non-null when the company exists. Commit 82c0819.
+**Prevention:** Whenever a route uses a LEFT JOIN to combine an entity with optional child rows, check the entity's own primary key (or a never-null alias like `resolved_id`) is non-null — not just `rows.length`. Pattern: `if (!rows[0]?.resolved_id) return err("Not found", 404);`
+**Affects:** hive
+
+---
+
+### 2026-04-02 `document.querySelector` as React focus trigger is fragile
+**What happened:** `src/app/company/[slug]/page.tsx` used `document.querySelector("[placeholder*='directive']")?.focus()` in 3 places to focus the directive input after user actions. The selector depends on the placeholder string being stable — any copy change would silently break the focus behavior with no error thrown.
+**Root cause:** Direct DOM manipulation with a text-content selector is the anti-pattern. React provides `useRef` precisely for stable, rename-safe references to DOM nodes.
+**Fix applied:** Added `const directiveInputRef = useRef<HTMLInputElement>(null)`, attached `ref={directiveInputRef}` to the `<input>`, and replaced all 3 `document.querySelector(...)?.focus()` calls with `directiveInputRef.current?.focus()`. Commit 82c0819.
+**Prevention:** Never use `document.querySelector` with text-content selectors (placeholder, aria-label, class names) to target React-rendered elements. Always use `useRef` for imperative DOM access. If a selector is needed for testing, use `data-testid`.
 **Affects:** hive
 
 ---

--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -182,6 +182,15 @@ async function reviewAndMergeOpenPRs(sql: ReturnType<typeof getDb>): Promise<{ c
                 ${JSON.stringify({ pr_number: pr.number, risk_score: analysis.riskScore, merged_items: (mergedItems as any[]).map((i: any) => i.id) })}::jsonb,
                 NOW(), NOW())
             `.catch(() => {});
+            // Schedule post-merge health check (5 min delay — wait for Sentry to ingest errors)
+            await qstashPublish("/api/health/post-merge-check", {
+              pr_number: pr.number,
+              pr_title: pr.title,
+              merged_at: new Date().toISOString(),
+            }, {
+              delay: 300,
+              deduplicationId: `post-merge-${pr.number}`,
+            }).catch(() => {});
           } else {
             console.log(`[backlog] Auto-merge failed for PR #${pr.number}: ${result.message}`);
             await sql`

--- a/src/app/api/health/post-merge-check/route.ts
+++ b/src/app/api/health/post-merge-check/route.ts
@@ -1,0 +1,121 @@
+/**
+ * POST /api/health/post-merge-check
+ *
+ * Called by QStash ~5 minutes after a PR is auto-merged.
+ * Fetches recent Sentry errors and checks for a regression spike
+ * (≥3 new distinct error patterns introduced since the merge).
+ * On spike: inserts a post_merge_regression agent_action and creates a P0 backlog item.
+ */
+
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+import { verifyCronAuth } from "@/lib/qstash";
+import { fetchRecentErrors, extractErrorPatterns } from "@/lib/sentry-api";
+
+const REGRESSION_THRESHOLD = 3; // distinct new error patterns = regression
+const BASELINE_WINDOW_SECS = 86400; // 24h baseline comparison window
+const POST_MERGE_WINDOW_SECS = 600;  // 10 min window to detect new errors
+
+export async function POST(req: Request) {
+  const auth = await verifyCronAuth(req);
+  if (!auth.authorized) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: 401 });
+  }
+
+  let body: { pr_number?: number; pr_title?: string; merged_at?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { pr_number, pr_title, merged_at } = body;
+  if (!pr_number) {
+    return NextResponse.json({ ok: false, error: "Missing pr_number" }, { status: 400 });
+  }
+
+  const sql = neon(process.env.DATABASE_URL!);
+
+  // Fetch errors from the post-merge window (recent 10 min) and baseline (24h)
+  const [recentErrors, baselineErrors] = await Promise.all([
+    fetchRecentErrors(POST_MERGE_WINDOW_SECS),
+    fetchRecentErrors(BASELINE_WINDOW_SECS),
+  ]);
+
+  const recentPatterns = extractErrorPatterns(recentErrors);
+  const baselinePatterns = extractErrorPatterns(baselineErrors);
+  const baselineKeys = new Set(baselinePatterns.map((p) => p.pattern));
+
+  // New patterns = those in recent window not present in baseline
+  const newPatterns = recentPatterns.filter((p) => !baselineKeys.has(p.pattern));
+
+  const isRegression = newPatterns.length >= REGRESSION_THRESHOLD;
+
+  await sql`
+    INSERT INTO agent_actions (agent, action_type, status, description, output, started_at, finished_at)
+    VALUES (
+      'backlog_dispatch',
+      'post_merge_regression',
+      ${isRegression ? "failure" : "success"},
+      ${`Post-merge health check for PR #${pr_number}: ${isRegression ? `REGRESSION — ${newPatterns.length} new error pattern(s)` : "clean"}`},
+      ${JSON.stringify({
+        pr_number,
+        pr_title,
+        merged_at,
+        new_patterns: newPatterns.length,
+        recent_errors: recentErrors.length,
+        baseline_errors: baselineErrors.length,
+        top_new_patterns: newPatterns.slice(0, 3).map((p) => ({
+          pattern: p.pattern,
+          count: p.count,
+          severity: p.severity,
+        })),
+      })}::jsonb,
+      NOW(),
+      NOW()
+    )
+  `.catch((err) => {
+    console.error("[post-merge-check] Failed to insert agent_action:", err);
+  });
+
+  if (isRegression) {
+    const description = [
+      `PR #${pr_number} (${pr_title ?? "unknown"}) merged at ${merged_at ?? "unknown"}.`,
+      `${newPatterns.length} new Sentry error patterns detected within 10 min of merge.`,
+      "",
+      "Top new patterns:",
+      ...newPatterns.slice(0, 3).map((p, i) => `${i + 1}. ${p.pattern} (${p.count} occurrences, ${p.severity})`),
+    ].join("\n");
+
+    await sql`
+      INSERT INTO hive_backlog (id, title, description, category, priority, status, notes, created_at, updated_at)
+      VALUES (
+        gen_random_uuid(),
+        ${`P0: Post-merge regression — PR #${pr_number}: ${pr_title ?? ""}`},
+        ${description},
+        'bugfix',
+        0,
+        'ready',
+        ${`Auto-created by post-merge health check. New error patterns: ${newPatterns.length}`},
+        NOW(),
+        NOW()
+      )
+    `.catch((err) => {
+      console.error("[post-merge-check] Failed to create regression backlog item:", err);
+    });
+
+    console.warn(
+      `[post-merge-check] REGRESSION detected after PR #${pr_number}: ${newPatterns.length} new pattern(s). Backlog item created.`
+    );
+  } else {
+    console.log(`[post-merge-check] PR #${pr_number} clean — ${recentErrors.length} recent errors, ${newPatterns.length} new patterns (threshold: ${REGRESSION_THRESHOLD})`);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    pr_number,
+    is_regression: isRegression,
+    new_patterns: newPatterns.length,
+    threshold: REGRESSION_THRESHOLD,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `/api/health/post-merge-check` — QStash-triggered 5 min after every auto-merged PR
- Compares 10-min post-merge Sentry errors against 24h baseline; creates P0 backlog item on ≥3 new patterns
- Wires delayed QStash publish into `reviewAndMergeOpenPRs()` after successful merge
- Documents interactive session PR merge / `syncIssueForBacklog` bypass in MISTAKES.md

## Test plan
- [ ] TypeScript clean (`tsc --noEmit` passes)
- [ ] CI passes
- [ ] After merge, check `agent_actions` for `post_merge_regression` entries when next PR auto-merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)