### PR TITLE
refactor: QStash fallback retry when Engineer dispatch is busy

### DIFF
--- a/src/app/api/backlog/dispatch/route.ts
+++ b/src/app/api/backlog/dispatch/route.ts
@@ -1256,9 +1256,12 @@ export async function POST(req: Request) {
     }
   }
   if (engineerBusy) {
-    // Don't retry — the running engineer will chain-dispatch when it finishes
+    // The running engineer will chain-dispatch when it finishes — but if it crashes before
+    // chaining (GitHub Actions timeout, OOM, network failure), no retry would ever fire.
+    // Schedule a QStash fallback retry so work is never permanently lost on engineer crash.
+    await scheduleChainRetry("engineer_busy", 20);
     logDispatchCycle("engineer_busy", { source: engineerBusySource });
-    return json({ dispatched: false, reason: "engineer_busy", source: engineerBusySource });
+    return json({ dispatched: false, reason: "engineer_busy", source: engineerBusySource, chain_retry: true });
   }
 
   // Per-agent hourly rate limit: prevent dispatch burst patterns


### PR DESCRIPTION
## Summary
- When the engineer_busy gate fires, the running Engineer is expected to chain-dispatch on completion
- If the Engineer crashes (GitHub Actions timeout, OOM, network failure), no retry would ever fire and pending work would be silently lost until the next Sentinel cycle
- Add QStash-scheduled fallback retry (20 min delay) so dispatch is guaranteed to re-run
- Add `chain_retry: true` to response body for consistency with all other early-exit cases

## Test plan
- [ ] Build passes (verified locally)
- [ ] Verify engineer_busy response now includes `chain_retry: true`
- [ ] Verify QStash retry fires ~20 min after engineer_busy detection

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)