### PR TITLE
feat: Vercel Blob offloading for large research content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@upstash/qstash": "^2.10.1",
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/blob": "^2.3.3",
         "@vercel/edge-config": "^1.4.3",
         "@vercel/speed-insights": "^2.0.0",
         "ai": "^6.0.141",
@@ -3901,6 +3902,22 @@
         }
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
+      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@vercel/edge-config": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.3.tgz",
@@ -4516,6 +4533,15 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -5633,6 +5659,35 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -6966,6 +7021,15 @@
         "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
@@ -7528,6 +7592,18 @@
         }
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7660,6 +7736,15 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@upstash/qstash": "^2.10.1",
     "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/blob": "^2.3.3",
     "@vercel/edge-config": "^1.4.3",
     "@vercel/speed-insights": "^2.0.0",
     "ai": "^6.0.141",

--- a/src/app/api/agents/dispatch/route.ts
+++ b/src/app/api/agents/dispatch/route.ts
@@ -15,6 +15,7 @@ import { cachedPlaybook } from "@/lib/redis-cache";
 import { compressResearchForAgent } from "@/lib/research-compression";
 import { qstashPublish } from "@/lib/qstash";
 import { verifyPlaybookUsage } from "@/lib/playbook-verification";
+import { resolveBlobContent, uploadIfLarge } from "@/lib/blob-storage";
 
 // Worker agents use unified LLM provider abstraction (src/lib/llm.ts)
 // Handles provider routing, fallbacks, rate limiting, and response normalization
@@ -307,8 +308,12 @@ ${capabilitiesSummary(company.capabilities)}`;
         sql`SELECT content FROM research_reports WHERE company_id = ${company.id} AND report_type = 'lead_list'`,
         sql`SELECT content FROM research_reports WHERE company_id = ${company.id} AND report_type = 'outreach_log'`,
       ]);
-      fullPrompt += `\n\nEXISTING LEADS: ${leadList ? JSON.stringify(leadList.content) : "None yet"}`;
-      fullPrompt += `\nOUTREACH LOG: ${outreachLog ? JSON.stringify(outreachLog.content) : "No outreach yet"}`;
+      const [leadContent, outreachContent] = await Promise.all([
+        leadList ? resolveBlobContent(leadList.content) : Promise.resolve(null),
+        outreachLog ? resolveBlobContent(outreachLog.content) : Promise.resolve(null),
+      ]);
+      fullPrompt += `\n\nEXISTING LEADS: ${leadContent ? JSON.stringify(leadContent) : "None yet"}`;
+      fullPrompt += `\nOUTREACH LOG: ${outreachContent ? JSON.stringify(outreachContent) : "No outreach yet"}`;
     }
 
     if (agentName === "growth") {
@@ -333,10 +338,15 @@ ${capabilitiesSummary(company.capabilities)}`;
         sql`SELECT content FROM research_reports WHERE company_id = ${company.id} AND report_type = 'llm_visibility'`,
         sql`SELECT content FROM research_reports WHERE company_id = ${company.id} AND report_type = 'content_performance'`,
       ]);
+      const [visContent, llmVisContent, contentPerfContent] = await Promise.all([
+        visSnapshot ? resolveBlobContent(visSnapshot.content) : Promise.resolve(null),
+        llmVis ? resolveBlobContent(llmVis.content) : Promise.resolve(null),
+        contentPerf ? resolveBlobContent(contentPerf.content) : Promise.resolve(null),
+      ]);
       // Context optimization: truncate large JSONB reports to prevent token bloat
-      if (visSnapshot) fullPrompt += `\n\nVISIBILITY DATA (from GSC):\n${truncateJson(visSnapshot.content, 2000)}`;
-      if (llmVis) fullPrompt += `\n\nLLM VISIBILITY:\n${truncateJson(llmVis.content, 1500)}`;
-      if (contentPerf) fullPrompt += `\n\nCONTENT PERFORMANCE (refresh recommendations):\n${truncateJson(contentPerf.content, 2000)}`;
+      if (visContent) fullPrompt += `\n\nVISIBILITY DATA (from GSC):\n${truncateJson(visContent, 2000)}`;
+      if (llmVisContent) fullPrompt += `\n\nLLM VISIBILITY:\n${truncateJson(llmVisContent, 1500)}`;
+      if (contentPerfContent) fullPrompt += `\n\nCONTENT PERFORMANCE (refresh recommendations):\n${truncateJson(contentPerfContent, 2000)}`;
     }
 
     // 5. Call the unified LLM interface with tool calling support
@@ -616,22 +626,28 @@ async function processOutreachResults(sql: any, company: any, output: string) {
       }
 
       const processedData = { ...parsed, leads: filteredLeads };
+      const processedStr = JSON.stringify(processedData);
+      const leadsBlobUrl = await uploadIfLarge(processedStr, `research/${company.id}/lead_list`);
+      const leadsContent = leadsBlobUrl ? JSON.stringify({ _blob_url: leadsBlobUrl }) : processedStr;
 
       await sql`
         INSERT INTO research_reports (company_id, report_type, content, summary)
-        VALUES (${company.id}, 'lead_list', ${JSON.stringify(processedData)}, ${`${filteredLeads.length} leads tracked (${originalCount - filteredCount} filtered)`})
+        VALUES (${company.id}, 'lead_list', ${leadsContent}::jsonb, ${`${filteredLeads.length} leads tracked (${originalCount - filteredCount} filtered)`})
         ON CONFLICT (company_id, report_type) DO UPDATE SET
-          content = ${JSON.stringify(processedData)}, summary = ${`${filteredLeads.length} leads tracked (${originalCount - filteredCount} filtered)`}, updated_at = now()
+          content = ${leadsContent}::jsonb, summary = ${`${filteredLeads.length} leads tracked (${originalCount - filteredCount} filtered)`}, updated_at = now()
       `;
       leadsUpdated = true;
     }
 
     if (parsed.emails_drafted?.length) {
+      const parsedStr = JSON.stringify(parsed);
+      const outreachBlobUrl = await uploadIfLarge(parsedStr, `research/${company.id}/outreach_log`);
+      const outreachContent = outreachBlobUrl ? JSON.stringify({ _blob_url: outreachBlobUrl }) : parsedStr;
       await sql`
         INSERT INTO research_reports (company_id, report_type, content, summary)
-        VALUES (${company.id}, 'outreach_log', ${JSON.stringify(parsed)}, ${`${parsed.emails_drafted.length} emails drafted`})
+        VALUES (${company.id}, 'outreach_log', ${outreachContent}::jsonb, ${`${parsed.emails_drafted.length} emails drafted`})
         ON CONFLICT (company_id, report_type) DO UPDATE SET
-          content = ${JSON.stringify(parsed)}, summary = ${`${parsed.emails_drafted.length} emails drafted`}, updated_at = now()
+          content = ${outreachContent}::jsonb, summary = ${`${parsed.emails_drafted.length} emails drafted`}, updated_at = now()
       `;
     }
 

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -1,5 +1,6 @@
 import { getDb, json, err } from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
+import { uploadIfLarge, isBlobMarker, deleteBlob } from "@/lib/blob-storage";
 
 export async function GET(req: Request) {
   const session = await requireAuth();
@@ -54,11 +55,24 @@ export async function POST(req: Request) {
   // Content is JSONB — pass stringified JSON so Neon stores it as JSONB, not as a text string
   const contentStr = typeof content === "string" ? content : JSON.stringify(content);
   const sourcesStr = sources ? (typeof sources === "string" ? sources : JSON.stringify(sources)) : null;
+
+  // If content exceeds 100KB, upload to Vercel Blob and store a marker instead
+  const blobUrl = await uploadIfLarge(contentStr, `research/${company_id}/${report_type}`);
+  const storedContent = blobUrl ? JSON.stringify({ _blob_url: blobUrl }) : contentStr;
+
+  // If replacing an existing blob, delete the old one to avoid orphans
+  const [existing] = await sql`
+    SELECT content FROM research_reports WHERE company_id = ${company_id} AND report_type = ${report_type}
+  `;
+  if (existing && isBlobMarker(existing.content) && blobUrl && existing.content._blob_url !== blobUrl) {
+    await deleteBlob(existing.content._blob_url);
+  }
+
   const [report] = await sql`
     INSERT INTO research_reports (company_id, report_type, content, summary, sources)
-    VALUES (${company_id}, ${report_type}, ${contentStr}::jsonb, ${summary || null}, ${sourcesStr}::jsonb)
+    VALUES (${company_id}, ${report_type}, ${storedContent}::jsonb, ${summary || null}, ${sourcesStr}::jsonb)
     ON CONFLICT (company_id, report_type) DO UPDATE SET
-      content = ${contentStr}::jsonb,
+      content = ${storedContent}::jsonb,
       summary = ${summary || null},
       sources = ${sourcesStr}::jsonb,
       updated_at = now()

--- a/src/lib/blob-storage.ts
+++ b/src/lib/blob-storage.ts
@@ -1,0 +1,80 @@
+/**
+ * Vercel Blob storage wrapper for large research content.
+ *
+ * Strategy: If content exceeds BLOB_SIZE_THRESHOLD_BYTES and BLOB_READ_WRITE_TOKEN
+ * is configured, upload to Blob and return a {_blob_url: "..."} marker object.
+ * Callers transparently resolve markers by calling resolveBlobContent().
+ *
+ * Graceful fallback: if the env var is absent, returns null (caller stores in DB as usual).
+ */
+
+import { put, del } from "@vercel/blob";
+
+// Store in blob if content string exceeds 100KB
+const BLOB_SIZE_THRESHOLD_BYTES = 100 * 1024;
+
+/** Type guard: is this JSONB content a blob URL marker? */
+export function isBlobMarker(content: unknown): content is { _blob_url: string } {
+  return (
+    typeof content === "object" &&
+    content !== null &&
+    "_blob_url" in content &&
+    typeof (content as Record<string, unknown>)._blob_url === "string"
+  );
+}
+
+/**
+ * Upload content to Vercel Blob if it exceeds the size threshold.
+ * Returns the blob URL, or null if blob storage is not configured or content is small.
+ */
+export async function uploadIfLarge(
+  content: string,
+  pathPrefix: string
+): Promise<string | null> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) return null;
+  if (content.length < BLOB_SIZE_THRESHOLD_BYTES) return null;
+
+  try {
+    const { url } = await put(`${pathPrefix}/${Date.now()}.json`, content, {
+      access: "public",
+      contentType: "application/json",
+      addRandomSuffix: true,
+    });
+    return url;
+  } catch (e) {
+    console.warn("[blob-storage] upload failed, falling back to DB storage:", e);
+    return null;
+  }
+}
+
+/**
+ * Resolve a content value that may be a blob marker or raw JSONB.
+ * If marker: fetch from Blob and parse. If raw: return as-is.
+ */
+export async function resolveBlobContent(content: unknown): Promise<unknown> {
+  if (!isBlobMarker(content)) return content;
+
+  try {
+    const res = await fetch(content._blob_url);
+    if (!res.ok) {
+      console.warn(`[blob-storage] fetch failed (${res.status}): ${content._blob_url}`);
+      return content; // return marker, caller decides what to do
+    }
+    return await res.json();
+  } catch (e) {
+    console.warn("[blob-storage] resolve failed:", e);
+    return content;
+  }
+}
+
+/**
+ * Delete a blob by URL. No-op if not a blob URL or token missing.
+ */
+export async function deleteBlob(url: string): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) return;
+  try {
+    await del(url);
+  } catch (e) {
+    console.warn("[blob-storage] delete failed:", e);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/blob-storage.ts` wrapper with `uploadIfLarge()`, `resolveBlobContent()`, `deleteBlob()`, and `isBlobMarker()` helpers
- Research POST route uploads content >100KB to Vercel Blob, stores `{_blob_url}` marker in Neon JSONB
- Dispatch route resolves blob markers transparently before injecting into agent prompts (outreach + growth paths)
- Orphan blob cleanup when replacing existing blob-backed content
- Graceful fallback: no-op when `BLOB_READ_WRITE_TOKEN` absent (works without Blob configured)

## Test plan
- [ ] Build passes in CI
- [ ] `uploadIfLarge` returns null when `BLOB_READ_WRITE_TOKEN` not set (existing behavior preserved)
- [ ] Research reports >100KB stored as blob markers in DB
- [ ] Agent prompts receive resolved content regardless of storage location

Closes #192
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)