### PR TITLE
feat: living ADRs — CEO reads and writes DECISIONS.md autonomously

### DIFF
--- a/.github/workflows/hive-ceo.yml
+++ b/.github/workflows/hive-ceo.yml
@@ -96,6 +96,7 @@ jobs:
             2. Only read `BRIEFING.md` if trigger is cycle_start or cycle_complete (skip for ceo_review)
             3. Fetch CEO context: curl -s "$HIVE_URL/api/agents/context?agent=ceo&company_slug=<slug>" -H "Authorization: Bearer $CRON_SECRET"
                This returns validation phase, cycle info, research summaries, playbook, tasks, directives, metrics, and recent scores — all in one call.
+            4. Before making any Hive platform-level architectural decision, read `DECISIONS.md` to check if it was already decided.
 
             ## Trigger-specific instructions
 

--- a/BRIEFING.md
+++ b/BRIEFING.md
@@ -684,6 +684,9 @@ Added `.github/workflows/actionlint.yml` — runs `rhysd/actionlint` on PRs touc
 ### 2026-04-02 [code] npm caching + teardown fix (PR #324, Issue #150)
 Added `actions/setup-node@v4` with `cache: 'npm'` to healer, spec-gen, and engineer workflows — speeds up repeated `npm install` calls by caching `~/.npm` between runs. Also fixed a latent bug: `hive-engineer.yml` teardown job was missing `actions/checkout@v4` entirely, causing it to fail whenever teardown was triggered.
 
+### 2026-04-03 [code] Blob storage utility + large-output handling (PR #375)
+Added `src/lib/blob-storage.ts` — a Vercel Blob utility for storing agent outputs that exceed Neon's row size limits. Updated `research/route.ts` and `dispatch/route.ts` to offload large payloads (>50KB) to blob storage and store only the blob URL in the DB. Prevents DB write failures on large Scout research dumps and verbose agent outputs. Items ff83dedd + 25f4741a marked done.
+
 ### 2026-04-02 [code] CEO chain dispatch → TypeScript (PR #325, Issue #151)
 Extracted the 130-line bash chain dispatch block from `hive-ceo.yml` into `scripts/chain-dispatch.ts`. TypeScript version uses `@neondatabase/serverless` for company repo lookup, native `fetch` for all HTTP calls, handles all triggers (`cycle_start`, `gate_approved`, `cycle_complete`/`ceo_review`), dispatches Growth + Outreach concurrently via `Promise.all()`, and sends Telegram notification on completion. Easier to test, type-safe, no bash escaping footguns.
 

--- a/prompts/ceo.md
+++ b/prompts/ceo.md
@@ -586,6 +586,39 @@ curl -X POST "https://hive-phi.vercel.app/api/decisions" \
 
 This creates a decision track record that improves strategic quality over time through retrospective analysis.
 
+## Architectural Decision Records (ADRs)
+
+When you make a **Hive platform-level architectural decision** — not a company-specific choice, but a decision about how Hive itself works — write it to `DECISIONS.md`. This prevents re-debating settled questions.
+
+**When to write an ADR (all of these apply to Hive infrastructure, not company products):**
+- Choosing a new data storage strategy (e.g., "store X in Blob not Neon")
+- Changing how agents communicate or are dispatched
+- Adopting a new external service or removing an existing one
+- Establishing a new agent or retiring an existing one
+- Making a cross-cutting architecture decision that affects multiple agents
+
+**Do NOT write ADRs for:**
+- Company-specific decisions (use Strategic Decision Logging API instead)
+- Routine planning choices (which tasks to run this cycle)
+- Temporary workarounds (document in MISTAKES.md instead)
+
+**Format (append to the end of DECISIONS.md):**
+```
+### ADR-NNN: Title
+**Date:** YYYY-MM-DD
+**Status:** accepted
+**Context:** What situation prompted this decision?
+**Decision:** What did we decide?
+**Alternatives considered:** What else was on the table?
+**Consequences:** What are the tradeoffs?
+```
+
+**Steps:**
+1. Check the last ADR number in DECISIONS.md: `grep "^### ADR-" DECISIONS.md | tail -1`
+2. Increment by 1 for the new ADR number
+3. Append the ADR using the Edit tool
+4. Also read DECISIONS.md at the start of a cycle if you're about to make an architectural change — it may already be documented
+
 ## GitHub Issue routing
 
 When creating a GitHub Issue for escalations or blockers:
@@ -601,3 +634,4 @@ Always use: `GH_TOKEN="$GH_PAT" gh issue create --repo carloshmiranda/{{COMPANY_
 - If you don't have enough data to decide, say so and propose how to get the data.
 - NEVER plan work that is in the `forbidden` list for the current validation phase.
 - **ALWAYS log strategic decisions using the decision logging API above.**
+- **Write an ADR to DECISIONS.md for Hive platform-level architectural decisions** (see ADR section above).


### PR DESCRIPTION
## Summary
- Adds ADR-writing instructions to `prompts/ceo.md` so the CEO agent knows when and how to append architectural decisions to `DECISIONS.md`
- Updates `hive-ceo.yml` context loading to instruct CEO to read `DECISIONS.md` before making platform architectural decisions
- Prevents re-debating settled Hive architectural choices across sessions

## What changes
- `prompts/ceo.md`: new "Architectural Decision Records (ADRs)" section with trigger conditions, format template, and step-by-step instructions; updated Rules section
- `.github/workflows/hive-ceo.yml`: one-line addition to context loading instructions

## Test plan
- [ ] Build passes (prompt-only change, no TypeScript changes)
- [ ] CEO prompt reads correctly with new section in place
- [ ] Actionlint passes (workflow YAML change is only a prompt string addition)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)