### PR TITLE
feat: ECC Phase A — hooks, model matrix, ts-guard skill

### DIFF
--- a/.claude/hooks/post-write-check.sh
+++ b/.claude/hooks/post-write-check.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# PostToolUse:Write hook — runs after every Write tool use
+# Checks: console.log leaks, edge runtime import violations
+# Advisory only — the file is already written
+
+# Read hook input JSON from stdin
+INPUT=$(cat)
+
+# Extract file path from tool input
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+except:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only check TypeScript/TSX files
+if [[ "$FILE_PATH" != *.ts && "$FILE_PATH" != *.tsx ]]; then
+  exit 0
+fi
+
+WARNINGS=()
+ERRORS=()
+
+# ── 1. console.log check ──────────────────────────────────────────────────────
+# console.log is noise in production logs. Use console.warn for structured output.
+if grep -qn "console\.log(" "$FILE_PATH" 2>/dev/null; then
+  SNIPPET=$(grep -n "console\.log(" "$FILE_PATH" | head -3 | sed 's/^/    /')
+  WARNINGS+=("console.log found — use console.warn for structured logging:\n$SNIPPET")
+fi
+
+# ── 2. Edge runtime import check ─────────────────────────────────────────────
+# Node.js-only APIs cannot run in Vercel Edge Runtime (middleware, /edge/ routes)
+IS_EDGE=false
+if [[ "$FILE_PATH" == */middleware.ts ]] || \
+   [[ "$FILE_PATH" == */middleware.tsx ]] || \
+   [[ "$FILE_PATH" =~ /route\.(ts|tsx)$ ]] && grep -q "runtime.*=.*['\"]edge['\"]" "$FILE_PATH" 2>/dev/null; then
+  IS_EDGE=true
+fi
+# Also check files that explicitly declare edge runtime
+if grep -q "export const runtime = ['\"]edge['\"]" "$FILE_PATH" 2>/dev/null; then
+  IS_EDGE=true
+fi
+
+if [ "$IS_EDGE" = true ]; then
+  NODE_ONLY_MODULES=("node:fs" "node:path" "node:os" "node:child_process" "node:crypto" "node:stream" "node:http" "node:https" "node:net" "node:tls" "node:dns" "node:cluster" "node:worker_threads" "\"fs\"" "\"path\"" "\"os\"" "\"child_process\"" "\"crypto\"" "\"stream\"" "\"http\"" "\"https\"" "\"net\"" "\"tls\"")
+  for MOD in "${NODE_ONLY_MODULES[@]}"; do
+    CLEAN_MOD="${MOD//\"/}"
+    if grep -q "from $MOD" "$FILE_PATH" 2>/dev/null || grep -q "require($MOD)" "$FILE_PATH" 2>/dev/null; then
+      ERRORS+=("🚫 EDGE VIOLATION: '$CLEAN_MOD' imported in edge file $FILE_PATH — will fail at runtime")
+    fi
+  done
+fi
+
+# ── Output ────────────────────────────────────────────────────────────────────
+if [ ${#ERRORS[@]} -gt 0 ] || [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo ""
+  echo "┌─ Post-Write Check: $(basename $FILE_PATH) ──────────────────────────────"
+
+  for E in "${ERRORS[@]}"; do
+    printf "│ %b\n" "$E"
+  done
+
+  for W in "${WARNINGS[@]}"; do
+    printf "│ ⚠️  %b\n" "$W"
+  done
+
+  if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "│"
+    echo "│ Fix edge violations before deploying — Vercel will reject the build."
+  fi
+
+  echo "└────────────────────────────────────────────────────────────────"
+  echo ""
+fi
+
+exit 0

--- a/.claude/hooks/session-stop-reminder.sh
+++ b/.claude/hooks/session-stop-reminder.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Stop hook — runs when Claude Code session ends
+# Reminds to run /context if changes were made this session
+
+# Check for uncommitted or staged changes
+HAS_STAGED=$(git diff --cached --name-only 2>/dev/null | head -1)
+HAS_UNSTAGED=$(git diff --name-only 2>/dev/null | head -1)
+HAS_UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | head -1)
+
+if [ -n "$HAS_STAGED" ] || [ -n "$HAS_UNSTAGED" ] || [ -n "$HAS_UNTRACKED" ]; then
+  echo ""
+  echo "┌─ Session End ───────────────────────────────────────────────────"
+  echo "│ 📸 Uncommitted changes detected. Before closing:"
+  echo "│"
+  echo "│   Run /context to:"
+  echo "│   • Sync BRIEFING.md + memory files with this session's work"
+  echo "│   • Mark completed backlog items as done in the DB"
+  echo "│   • Prevent context drift for the next session"
+  echo "│"
+  echo "│   Skipping /context = next session inherits stale state."
+  echo "└─────────────────────────────────────────────────────────────────"
+  echo ""
+  exit 0
+fi
+
+# Check for recent commits not yet pushed
+UNPUSHED=$(git log @{u}..HEAD --oneline 2>/dev/null | head -1)
+if [ -n "$UNPUSHED" ]; then
+  echo ""
+  echo "┌─ Session End ───────────────────────────────────────────────────"
+  echo "│ 🚀 Unpushed commits detected. Remember to push when ready."
+  echo "│   Run /context if BRIEFING.md hasn't been updated this session."
+  echo "└─────────────────────────────────────────────────────────────────"
+  echo ""
+fi
+
+exit 0

--- a/.claude/scratch/ecc-absorption-plan.md
+++ b/.claude/scratch/ecc-absorption-plan.md
@@ -1,0 +1,47 @@
+# Everything-Claude-Code Absorption Plan
+
+**Source:** https://github.com/affaan-m/everything-claude-code
+**Date:** 2026-04-04
+**Status:** Phase A complete — Phase B in progress
+
+## Phase A (DONE): Hook Enforcement + Model Matrix + Build Error Rule + Docs-Lookup
+- [x] PostToolUse:Write hook (console.log check, edge runtime check) — `.claude/hooks/post-write-check.sh`
+- [x] Stop hook (context reminder) — `.claude/hooks/session-stop-reminder.sh`
+- [x] Hooks registered in `.claude/settings.json`
+- [x] CLAUDE.md: model selection matrix
+- [x] CLAUDE.md: docs-lookup rule
+- [x] CLAUDE.md: build error minimal intervention rule
+- [x] .claude/skills/ts-guard/SKILL.md
+
+## Phase B (next PR): TypeScript Reviewer + Security Reviewer + Context Injection
+- [ ] .claude/skills/ts-review/SKILL.md
+- [ ] .claude/skills/security-scan/SKILL.md
+- [ ] Context split: dev.md, research.md, review.md carved from CLAUDE.md
+- [ ] Update /do SKILL.md: Phase 3a (TS review) + Phase 3b (security check)
+
+## Phase C: Growth/SEO Skills + TDD for Critical Paths
+- [ ] Growth agent prompt: SEO audit, content brief, CRO checklist, email copy review
+- [ ] Engineer prompt: test-first for auth/payments/dispatch
+
+## Phase D (future): Loop-Operator + Performance Optimizer + Continuous Learning
+- [ ] Design schema for continuous learning
+- [ ] Loop-operator skill for interactive sessions
+- [ ] Performance optimizer for front-end changes
+
+---
+
+## Key Principles (both lenses)
+
+### Autonomous Agent Quality
+- TypeScript/App Router reviewer in /do Phase 3
+- Security scan in /do Phase 4
+- Docs-lookup before any SDK method usage
+- Build error minimal intervention (scope < 5% of file)
+- SEO/content skills injected into Growth agent
+
+### Interactive Session Quality  
+- PostToolUse hooks enforce checklists physically (LLM can't skip)
+- Stop hook triggers /context reminder
+- Model matrix: Haiku for exploration, Sonnet for coding, Opus for architecture
+- ts-guard skill for on-demand TypeScript/edge runtime audit
+- security-scan skill for on-demand security review

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,30 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-write-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-stop-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/ts-guard/SKILL.md
+++ b/.claude/skills/ts-guard/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ts-guard
+description: Lightweight TypeScript + Next.js App Router compliance checker for interactive sessions. Invoke when the user says '/ts-guard', 'check for TS errors', 'audit edge runtime', 'check console.logs', 'scan for edge violations', or 'verify App Router compliance'. Also invoke after writing multiple TypeScript files and before opening a PR.
+---
+
+<ts-guard>
+You are a TypeScript and Next.js App Router compliance auditor. Your job is to catch errors that the compiler misses and enforce Hive-specific conventions across recently changed files.
+
+## What to Check
+
+### 1. TypeScript Errors
+Run `npx tsc --noEmit` and report all errors with file:line. Do not proceed to other checks if TypeScript errors exist — fix them first.
+
+### 2. Edge Runtime Compliance
+Edge runtime files (middleware.ts and any file with `export const runtime = "edge"`) cannot import Node.js-only modules.
+
+**Banned in edge files:**
+- `node:fs`, `node:path`, `node:os`, `node:child_process`, `node:crypto`, `node:stream`, `node:http`, `node:https`, `node:net`, `node:tls`, `node:dns`, `node:cluster`, `node:worker_threads`
+- `"fs"`, `"path"`, `"os"`, `"child_process"`, `"crypto"`, `"stream"`, `"http"`, `"https"`, `"net"`, `"tls"`
+
+For each violation: report `file:line — imported 'X' which is Node.js-only. Remove or move to a non-edge file.`
+
+### 3. console.log Leaks
+In any `.ts` or `.tsx` file: `console.log(` is production noise. Hive uses `console.warn` for structured logging (per MISTAKES.md).
+
+For each occurrence: report `file:line — console.log found. Replace with console.warn or remove.`
+
+### 4. App Router Anti-Patterns
+Check recently changed files for:
+
+| Anti-pattern | Rule |
+|---|---|
+| `export` of helpers from `route.ts` | Route files must not export anything except `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`. Shared logic goes in `src/lib/`. |
+| `'use client'` on a page or layout | Client boundary should be pushed to leaf components. Flag pages/layouts marked `'use client'` unless unavoidable. |
+| `fetch()` inside a Client Component without SWR/React Query | Client-side data fetching should use a hook, not bare `fetch()` in a render function. |
+| `<img>` tags | Must use `next/image` for all images. |
+| Raw string interpolation in SQL | All SQL must use parameterized queries (`$1`, `$2`, etc.), never string template literals. |
+
+### 5. Missing Error Handling at Boundaries
+In API route handlers (`src/app/api/`): any handler that calls Neon, Stripe, Resend, or external APIs must have a try/catch or return a structured error. Flag bare `await` calls in API routes with no surrounding error handling.
+
+## How to Run
+
+1. **Get the diff**: `git diff HEAD` (or `git diff main...HEAD` for the full branch diff)
+2. **Identify changed TypeScript files**
+3. **Run tsc**: `npx tsc --noEmit 2>&1 | head -50`
+4. **Grep for issues** in changed files only — don't flag pre-existing issues in untouched files
+5. **Report findings** grouped by severity:
+
+```
+## ts-guard Report
+
+### TypeScript Errors (BLOCKING)
+- file:line — error message
+
+### Edge Runtime Violations (BLOCKING)
+- file:line — issue
+
+### console.log (WARN)
+- file:line — issue
+
+### App Router Anti-Patterns (WARN)
+- file:line — issue
+
+### Missing Error Handling (WARN)
+- file:line — issue
+
+---
+Status: CLEAN | WARNINGS ONLY | BLOCKING ISSUES FOUND
+```
+
+## Severity
+
+- **BLOCKING**: TypeScript errors and edge runtime violations will fail builds or crash at runtime. Fix before committing.
+- **WARN**: console.log, anti-patterns, and missing error handling should be fixed but won't block CI.
+
+## Scope Constraint
+
+Only audit files changed in the current diff. Do not report pre-existing issues in unmodified files — that creates noise and violates the minimal intervention rule.
+</ts-guard>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,39 @@ Format: `[agent] action: result (context)` — consistent for Sentinel parsing.
 - NEVER put literal `${{ }}` in prompt text — GitHub evaluates ALL expressions, even in multi-line strings
 - Files: `hive-<agent>.yml` (Hive), `hive-<function>.yml` (company repos)
 
+## Model Selection
+
+Choose the right model for the task. Over-indexing on Opus burns budget; under-indexing on Haiku loses quality.
+
+| Task | Model | Rationale |
+|------|-------|-----------|
+| Codebase exploration, file reading, grep | Haiku | Fast, cheap — no reasoning needed |
+| Routine coding, bug fixes, refactoring | Sonnet | Best quality/cost for daily work |
+| Architecture, security design, complex trade-offs | Opus | Reasoning-intensive decisions justify the cost |
+| Agent dispatches (Ops, Growth, Outreach) | Haiku or Sonnet via OpenRouter | Keep Claude budget for Engineer + CEO |
+
+## Docs-Lookup Rule
+
+**Never rely on training data for external SDK or API method signatures.** APIs change. Training data is stale.
+
+Before writing code that calls any external SDK, library, or API (Stripe, Neon, Resend, QStash, Sentry, Next.js App Router internals, etc.):
+1. Check if the method signature is already used correctly in the codebase (Grep first)
+2. If uncertain: use the `make-plan` skill or `WebFetch` to verify against current official docs
+3. If a method raises a type error or behaves unexpectedly: fetch the docs before guessing a fix
+
+This rule applies to **every** external dependency — including ones you're confident about.
+
+## Build Error Minimal Intervention
+
+When fixing a TypeScript or build error, the fix must be **minimal and surgical**:
+- Fix only the breaking change — do not refactor surrounding code
+- Touch less than 5% of the modified file
+- Do not add error handling, comments, or type annotations to code you didn't break
+- Do not rename variables or restructure unrelated logic
+- If the error is in a file you don't fully understand, read the full file before touching it
+
+**The goal is a passing build with zero unintended changes.** If the minimal fix seems risky, escalate — don't expand scope.
+
 ## Code Standards
 
 - TypeScript everywhere, Next.js App Router, Tailwind CSS


### PR DESCRIPTION
## Summary

- **PostToolUse:Write hook** (`.claude/hooks/post-write-check.sh`): runs after every Write tool use on TypeScript/TSX files — detects `console.log` leaks and Node.js-only module imports in edge runtime files. Advisory output only (non-blocking).
- **Stop hook** (`.claude/hooks/session-stop-reminder.sh`): runs when Claude Code session ends — reminds to run `/context` if uncommitted changes or unpushed commits are detected.
- **CLAUDE.md additions**: three new rules — model selection matrix (Haiku/Sonnet/Opus by task type), docs-lookup rule (never rely on training data for SDK signatures), build error minimal intervention rule (<5% of file touched, no refactoring during fixes).
- **`ts-guard` skill** (`.claude/skills/ts-guard/SKILL.md`): on-demand TypeScript + Next.js App Router compliance checker for interactive sessions. Runs tsc, checks edge runtime imports, detects console.log, flags App Router anti-patterns, identifies missing error handling at API boundaries.

## Test plan

- [ ] Open a `.ts` file, add a `console.log(` and use the Write tool — hook should print warning
- [ ] Open a `middleware.ts` file, import `node:fs`, use Write tool — hook should print edge violation error
- [ ] End a session with uncommitted changes — Stop hook should print `/context` reminder
- [ ] Run `/ts-guard` in an interactive session — skill should invoke and run checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)