### PR TITLE
feat: ECC Phase B — ts-review + security-scan + context split + /do gates

### DIFF
--- a/.claude/context/dev.md
+++ b/.claude/context/dev.md
@@ -1,0 +1,121 @@
+# Hive — Developer Context
+
+Focused reference for coding sessions. Load this when implementing features, fixing bugs, or writing any code.
+
+---
+
+## Code Standards
+
+- TypeScript everywhere, Next.js App Router, Tailwind CSS
+- Neon serverless driver (`@neondatabase/serverless`), Stripe SDK, Resend SDK
+- No ORMs — raw SQL with parameterized queries
+- API routes return: `{ ok: boolean, data?: any, error?: string }`
+
+### Accessibility Standards (EAA Compliance)
+
+- **Form validation**: Every error must name the specific field and describe how to fix it. Use `aria-describedby` to link error messages to form fields.
+- **Interactive elements**: Every icon-only button needs `aria-label`. Every image needs descriptive `alt` text.
+- **Focus management**: All interactive elements must have visible focus indicators (`:focus-visible` ring).
+- **Color contrast**: Text must meet 7:1 contrast ratio. Use `text-secondary` (gray-600) for secondary text.
+- **Semantic HTML**: Use `<main>`, skip-to-content links, and proper heading hierarchy.
+
+---
+
+## Model Selection
+
+Choose the right model for the task. Over-indexing on Opus burns budget; under-indexing on Haiku loses quality.
+
+| Task | Model | Rationale |
+|------|-------|-----------|
+| Codebase exploration, file reading, grep | Haiku | Fast, cheap — no reasoning needed |
+| Routine coding, bug fixes, refactoring | Sonnet | Best quality/cost for daily work |
+| Architecture, security design, complex trade-offs | Opus | Reasoning-intensive decisions justify the cost |
+| Agent dispatches (Ops, Growth, Outreach) | Haiku or Sonnet via OpenRouter | Keep Claude budget for Engineer + CEO |
+
+---
+
+## Docs-Lookup Rule
+
+**Never rely on training data for external SDK or API method signatures.** APIs change. Training data is stale.
+
+Before writing code that calls any external SDK, library, or API (Stripe, Neon, Resend, QStash, Sentry, Next.js App Router internals, etc.):
+1. Check if the method signature is already used correctly in the codebase (Grep first)
+2. If uncertain: use the `make-plan` skill or `WebFetch` to verify against current official docs
+3. If a method raises a type error or behaves unexpectedly: fetch the docs before guessing a fix
+
+This rule applies to **every** external dependency — including ones you're confident about.
+
+---
+
+## Build Error Minimal Intervention
+
+When fixing a TypeScript or build error, the fix must be **minimal and surgical**:
+- Fix only the breaking change — do not refactor surrounding code
+- Touch less than 5% of the modified file
+- Do not add error handling, comments, or type annotations to code you didn't break
+- Do not rename variables or restructure unrelated logic
+- If the error is in a file you don't fully understand, read the full file before touching it
+
+**The goal is a passing build with zero unintended changes.** If the minimal fix seems risky, escalate — don't expand scope.
+
+---
+
+## Naming Standards
+
+### Git branches
+- Agent work: `hive/<agent>-<company>-<short-desc>`
+- Company builds: `hive/cycle-<N>-<task-id>`
+- Hive improvements: `hive/improvement/<slug>`
+
+### Commit messages
+Conventional commits: `feat:`, `fix:`, `refactor:`, `content:`, `chore:`, `docs:`
+
+### Workflow run names
+Format: `"Agent: trigger — context"` (e.g., `CEO: cycle_start — senhorio`)
+
+### Dispatch event types
+snake_case: `cycle_start`, `cycle_complete`, `gate_approved`, `feature_request`, `research_request`, `evolve_trigger`, `healer_trigger`, `pipeline_low`, `company_killed`, `stripe_payment`
+
+### Database naming
+Tables: snake_case plural. Columns: snake_case. Timestamps: `_at` suffix. Enums: lowercase snake_case.
+
+### Log messages
+Format: `[agent] action: result (context)` — consistent for Sentinel parsing.
+
+### Workflow YAML
+- NEVER put literal `${{ }}` in prompt text — GitHub evaluates ALL expressions, even in multi-line strings
+- Files: `hive-<agent>.yml` (Hive), `hive-<function>.yml` (company repos)
+
+---
+
+## Skills Reference
+
+Always invoke relevant skills before starting work. Do not rely on keyword auto-triggering alone — check this list at the start of any task that touches these domains.
+
+| Skill | Invoke when... |
+|-------|----------------|
+| `ui-ux-pro-max` | Any UI work: colors, fonts, components, layouts, accessibility audits. **READ the CSV data files** — the skill provides instructions but not the data itself. |
+| `frontend-design` | Building landing pages, marketing sites, or any distinctive visual UI |
+| `baseline-ui` | Starting any UI work — enforces stack, animation, typography, and layout constraints |
+| `fixing-accessibility` | Adding or changing any interactive element (buttons, forms, dialogs, links) |
+| `shadcn-ui` | Adding or modifying shadcn/ui components in a company app |
+| `tailwind-company` | Styling a company app, configuring design tokens in globals.css |
+| `neon-company-db` | Setting up or querying a company's Neon Postgres database |
+| `stripe-integration` | Adding payments, subscriptions, webhooks, or Stripe Checkout to a company |
+| `resend-email` | Adding transactional email or onboarding sequences to a company |
+| `sentry-company` | Adding error monitoring to a portfolio company |
+| `sentry-nextjs-sdk` | Full Sentry setup for any Next.js app |
+| `sentry-fix-issues` | Diagnosing and fixing production errors reported in Sentry |
+| `vercel-react-best-practices` | Writing or reviewing any React/Next.js code — performance, data fetching, bundle size |
+| `neon-postgres-egress-optimizer` | High DB bills, slow queries, excessive egress, or N+1 patterns |
+| `hive-agent-authoring` | Writing or editing any agent prompt, wiring a new dispatch event, checking turn budgets |
+| `hive-debugging` | Any agent failure, circuit breaker trip, zombie action, QStash DLQ issue, or dispatch problem |
+| `make-plan` | Any complex implementation touching multiple systems, APIs, or files. Run BEFORE writing code. Deploys subagents for doc discovery, codebase context, and constraint analysis. |
+| `do` | Executing a plan after `/make-plan` or when Carlos says "implement this". Deploys subagents for each phase and enforces verification → ts-review → security-scan → anti-pattern → quality → commit gates. |
+| `define-task` | Defining acceptance criteria before starting any new feature or task |
+| `ts-guard` | On-demand TypeScript + edge runtime audit for interactive sessions |
+| `ts-review` | Automated TS + App Router gate in the `/do` pipeline (Phase 3a — runs automatically) |
+| `security-scan` | Automated security review in the `/do` pipeline (Phase 3b — runs automatically) |
+| `seo` | Any SEO work on a portfolio company: audit, technical SEO, content quality, schema, local SEO, GEO/AI-search, backlinks, hreflang, sitemaps, programmatic SEO, competitor pages |
+| `ads` | Any paid advertising work: Google Ads, Meta, YouTube, LinkedIn, TikTok, Microsoft, Apple Search Ads — audits, campaign planning, brand DNA extraction, creative briefs |
+| `blog` | Full blog lifecycle: write, rewrite, outline, brief, SEO check, schema, cannibalization, taxonomy, strategy, analyze, audit, factcheck, GEO/AI citations, image gen, audio, charts, Google APIs, NotebookLM, persona, repurpose, editorial calendar |

--- a/.claude/context/research.md
+++ b/.claude/context/research.md
@@ -1,0 +1,60 @@
+# Hive — Research & Operations Context
+
+Venture orchestrator operating rules. Load this when planning company strategy, dispatching agents, or reasoning about the business.
+
+---
+
+## Context Protocol
+
+Four tools write to the shared knowledge layer: Claude Chat (brainstorming → update prompts), Claude Code (direct edits + commits), Orchestrator (Step 9 reflection → rewrites BRIEFING.md from Neon data), Carlos (manual edits + dashboard directives). Git repo is the single source of truth. Neon DB holds operational data (playbook, agent_actions, cycles, metrics, **backlog**). Backlog items live exclusively in `hive_backlog` DB table — BACKLOG.md is auto-generated, never edited.
+
+---
+
+## Operating Rules
+
+### 1. Budget-aware parallel execution
+Up to 2 companies simultaneously. Sentinel ranks by priority score (tasks, staleness, lifecycle, directives). Health gate blocks when 2+ brain agents running. >70% Claude budget → max 1 dispatch, >90% → escalations only.
+
+### 2. State lives in Neon
+Never store state in files. Read/write via Hive API (`/api/*`). Every action, decision, metric → database.
+
+### 3. Four human gates
+Require Carlos's approval: **new_company**, **growth_strategy**, **spend_approval** (>€20), **kill_company**. Everything else: execute autonomously.
+
+### 4. Three-attempt escalation
+Attempt 1: try. Attempt 2: reflect + different approach. Attempt 3: Auto-Healer. Still failing → escalation approval gate.
+
+### 5. Playbook-first
+Before Growth/SEO/marketing: read `playbook` table. After success with measurable outcomes: write new entry.
+
+### 6. Prompt versioning
+Agent prompts in `agent_prompts` table. Evolver proposes changes → shadow testing → approval gate.
+
+### 7. Completion status protocol
+Every agent action and interactive session task must close with one of four statuses:
+- **DONE** — task complete, all criteria verified, no open issues
+- **DONE_WITH_CONCERNS** — task complete but [specific concern flagged for follow-up]
+- **NEEDS_CONTEXT** — blocked on missing information; state exactly what is needed
+- **BLOCKED** — hard blocker prevents progress; escalate or stop
+
+When writing to `agent_actions`, map: DONE → `status=success`, BLOCKED → `status=failure`. For DONE_WITH_CONCERNS and NEEDS_CONTEXT, set `status=success` and include the status string in `output` JSON under `"completion_status"`.
+
+### 8. Subagent context injection
+Dispatch payloads must include full task context — not just IDs. When dispatching Engineer, Growth, or Healer:
+- Include `title`, `description`, and `acceptance_criteria` from the backlog item
+- Include relevant recent context (last CEO score, last error pattern, current metrics)
+- Include the playbook entries that apply (by slug)
+
+Agents that receive only an ID must fetch everything themselves, adding latency and DB round-trips. Agents that receive full context can start reasoning immediately.
+
+---
+
+## Validation-Gated Build (ADR-024)
+
+Companies progress through phases based on validation score (0-100) from real metrics, not cycle count. Computed in `src/lib/validation.ts`, injected via `/api/agents/context`. CEO is the only agent with phase logic — it gates what gets planned. See ARCHITECTURE.md for phase details and data collection.
+
+---
+
+## Directives
+
+Carlos sends directives via dashboard command bar or GitHub Issues (`hive-directive` label). CEO sees them as PRIORITY items that override normal planning. Auto-closed after processing.

--- a/.claude/context/review.md
+++ b/.claude/context/review.md
@@ -1,0 +1,37 @@
+# Hive — Review & Self-Improvement Context
+
+Anti-patterns and session hygiene. Load this when reviewing code, wrapping up a session, or doing any self-improvement work.
+
+---
+
+## Red Flags — Interactive Session Anti-Patterns
+
+These are the rationalizations that appear most often in sessions that produce regressions or lose context. They are named here so they can be recognized and refused at decision time, not discovered in MISTAKES.md afterward.
+
+| Rationalization | Why it's wrong |
+|----------------|----------------|
+| "The build passes, so it's done." | `npm run build` passes on incorrect logic all the time. Acceptance criteria must be verified explicitly — not inferred from CI. |
+| "It worked locally, should be fine on Vercel." | Edge runtime ≠ Node.js. Next.js App Router has different import restrictions. `crypto`, `fs`, and some npm packages break silently at deploy time. |
+| "The PR is small — no need for careful review." | Most entries in MISTAKES.md came from "small" PRs. Size is not a proxy for risk. |
+| "I'll handle that edge case in the next session." | The next session starts from a summary, not full context. Edge cases deferred across compaction boundaries reliably disappear. |
+| "The test covers the happy path — that's the main flow." | Hive's production failures are almost always in error paths: missing env vars, Neon timeouts, QStash auth failures, null returns from Sentry. |
+| "I'll update BRIEFING.md / run `/context` at the end." | Sessions end abruptly. If `/context` isn't run before closing, the next session inherits stale state and makes wrong recommendations. |
+| "This is a Hive infra change, not a company change — no need to check MISTAKES.md." | MISTAKES.md covers both. Many infra patterns (auth middleware, route exports, env var naming) have been broken and re-broken. |
+| "I already know what this file does — no need to read it first." | Skipping a Read before Edit is how stale assumptions ship. Always read before modifying. |
+
+---
+
+## Self-Improvement Rules
+
+### After every Claude Code session (mandatory — run `/context` or do manually):
+1. Something broke → MISTAKES.md
+2. Better approach discovered → MISTAKES.md or backlog DB (`mcp__hive__hive_backlog_create`)
+3. Architectural decision made → DECISIONS.md
+4. Project state changed → update memory files
+5. Architecture/flows/structure changed → update CLAUDE.md + ARCHITECTURE.md
+6. Append `[code]` entry to BRIEFING.md "Recent Context"
+7. Update backlog DB — use `mcp__hive__hive_backlog_update` (done items) and `mcp__hive__hive_backlog_create` (new gaps)
+8. **Do NOT skip this.** Context drift causes wrong recommendations in future sessions.
+
+### Self-assigned improvement flow:
+Orchestrator picks P2 items → branch `hive/improvement/{slug}` → implement → build verify → PR → approval gate → Carlos reviews.

--- a/.claude/scratch/ecc-absorption-plan.md
+++ b/.claude/scratch/ecc-absorption-plan.md
@@ -2,7 +2,7 @@
 
 **Source:** https://github.com/affaan-m/everything-claude-code
 **Date:** 2026-04-04
-**Status:** Phase A complete — Phase B in progress
+**Status:** Phase A complete — Phase B complete — Phase C next
 
 ## Phase A (DONE): Hook Enforcement + Model Matrix + Build Error Rule + Docs-Lookup
 - [x] PostToolUse:Write hook (console.log check, edge runtime check) — `.claude/hooks/post-write-check.sh`
@@ -13,11 +13,11 @@
 - [x] CLAUDE.md: build error minimal intervention rule
 - [x] .claude/skills/ts-guard/SKILL.md
 
-## Phase B (next PR): TypeScript Reviewer + Security Reviewer + Context Injection
-- [ ] .claude/skills/ts-review/SKILL.md
-- [ ] .claude/skills/security-scan/SKILL.md
-- [ ] Context split: dev.md, research.md, review.md carved from CLAUDE.md
-- [ ] Update /do SKILL.md: Phase 3a (TS review) + Phase 3b (security check)
+## Phase B (DONE): TypeScript Reviewer + Security Reviewer + Context Injection
+- [x] .claude/skills/ts-review/SKILL.md
+- [x] .claude/skills/security-scan/SKILL.md
+- [x] Context split: dev.md, research.md, review.md carved from CLAUDE.md
+- [x] Update /do SKILL.md: Phase 3a (TS review) + Phase 3b (security check)
 
 ## Phase C: Growth/SEO Skills + TDD for Critical Paths
 - [ ] Growth agent prompt: SEO audit, content brief, CRO checklist, email copy review

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -54,9 +54,29 @@ Verification subagent must check:
 3. No regressions — do adjacent features still work?
 4. Edge runtime compliance — no Node.js-only imports in middleware/edge routes
 
-**If any criterion FAILs**: Do NOT proceed to Step 3. Return to Step 1 with the failure details as context for a fix subagent. Retry up to 2 times before escalating to Carlos.
+**If any criterion FAILs**: Do NOT proceed to Step 3a. Return to Step 1 with the failure details as context for a fix subagent. Retry up to 2 times before escalating to Carlos.
 
-#### Step 3: Anti-Pattern Subagent
+#### Step 3a: ts-review Gate
+
+Invoke the `ts-review` skill with the diff of all changes in this phase.
+
+The skill checks: TypeScript errors (BLOCKING), edge runtime violations (BLOCKING), App Router violations (BLOCKING — route.ts exports, `<img>` tags, SQL string interpolation, `'use client'` on pages), missing error handling at API boundaries (WARN), console.log leaks (WARN).
+
+**If BLOCKED**: Do NOT proceed to Step 3b. Dispatch a fix subagent with the blocking issue list from the ts-review report. Re-run ts-review after the fix. Max 2 fix attempts before escalating to Carlos.
+
+**If PASS**: Proceed to Step 3b.
+
+#### Step 3b: security-scan Gate
+
+Invoke the `security-scan` skill with the diff of all changes in this phase.
+
+The skill runs three stages: Red Team (attack surface — injection, auth gaps, data exposure, secrets), Blue Team (defenses — input validation, sanitization, rate limiting, CSRF), Auditor (Hive standards + OWASP Top 10 quick check).
+
+**If BLOCKED on CRITICAL or HIGH**: Do NOT proceed to Step 4. Dispatch a fix subagent with the blocking issue list and the recommended fix pattern from the security-scan report. Re-run security-scan after the fix. Max 2 fix attempts before escalating to Carlos.
+
+**If PASS (or MEDIUM/LOW only)**: Proceed to Step 4.
+
+#### Step 4: Anti-Pattern Subagent
 
 Deploy an anti-pattern review subagent with:
 - The diff of all changes in this phase
@@ -65,7 +85,7 @@ Deploy an anti-pattern review subagent with:
 If findings are **HIGH severity** (security, data loss risk): block and fix before committing.
 If findings are **LOW/MEDIUM**: note them, continue.
 
-#### Step 4: Code Quality Subagent
+#### Step 5: Code Quality Subagent
 
 Deploy a code quality subagent with:
 - The diff of all changes in this phase
@@ -73,9 +93,9 @@ Deploy a code quality subagent with:
 
 If duplicates found: fix before committing.
 
-#### Step 5: Commit Subagent
+#### Step 6: Commit Subagent
 
-Only reached if Steps 2–4 pass (or only LOW severity issues found in 3–4).
+Only reached if Steps 2–5 pass (or only LOW severity issues found in Steps 4–5).
 
 Deploy a commit subagent with:
 - The list of modified files
@@ -113,6 +133,8 @@ After each phase, report:
 
 Commit: [SHA] — [message]
 Verification: all [N] criteria PASS
+ts-review: PASS / [count] WARNs noted
+security-scan: PASS / [count] MEDIUM issues noted
 Anti-patterns: CLEAN / [count] LOW severity noted
 Quality: [summary]
 

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: security-scan
+description: Three-stage security review for the /do pipeline. Invoked as Phase 3b in /do after ts-review passes. Runs red-team, blue-team, and auditor lenses against the phase diff. Also invoke when user says '/security-scan', 'security review', or 'run security check'.
+---
+
+<security-scan>
+You are a three-stage security reviewer in the /do execution pipeline. You run AFTER ts-review passes and BEFORE the commit subagent. Your job is to catch security issues in the diff of the current phase — not the entire codebase.
+
+## Scope Constraint
+
+**Only audit files changed in the current phase diff.** Do not flag pre-existing issues in unmodified files. This is a diff-scoped gate, not a full project security audit.
+
+## Three-Stage Process
+
+### Stage 1: Red Team — Attack Surface Analysis
+
+Think as an attacker. For each changed file, ask: "If I could send any input to this code, what could I do?"
+
+Check for:
+
+**Injection vulnerabilities:**
+- SQL injection: any SQL using string concatenation or template literals instead of `$1`/`$2` params → CRITICAL
+- Command injection: any use of `child_process.exec`, `eval`, or similar with user-controlled input → CRITICAL
+- Path traversal: file system operations (read/write/unlink) where the path derives from user input without normalization → HIGH
+- XSS: any place where user-supplied strings are inserted into HTML without escaping → HIGH
+
+**Authentication/Authorization gaps:**
+- API routes without auth validation (`getServerSession` / `auth()` check missing) → HIGH
+- Middleware bypasses (routes that should be protected but aren't in the matcher) → HIGH
+- IDOR patterns: fetching/modifying resources using user-supplied IDs without ownership check → HIGH
+
+**Data exposure:**
+- Returning more fields than needed (e.g., full user object including hashed password) → MEDIUM
+- Logging sensitive values (tokens, keys, passwords, PII) to console → HIGH
+- Stack traces or internal errors exposed in API responses → MEDIUM
+
+**Secrets and configuration:**
+- Hardcoded secrets, tokens, or API keys in source files → CRITICAL
+- `NEXT_PUBLIC_` prefix on variables that should stay server-only → HIGH
+- Env vars used without existence checks in critical paths → MEDIUM
+
+### Stage 2: Blue Team — Defense Check
+
+Think as a defender. For each attack surface found (or not found), verify whether defenses exist:
+
+**Input validation:**
+- Are user-supplied values validated with Zod or equivalent before use?
+- Are numeric inputs bounded (min/max)?
+- Are string inputs length-limited?
+
+**Output sanitization:**
+- Is HTML output escaped where user data is included?
+- Are error messages generic (not leaking internals) in API responses?
+
+**Rate limiting:**
+- Do mutating endpoints (POST/PUT/PATCH/DELETE) have any rate limiting or abuse prevention?
+- Are unauthenticated endpoints especially protected?
+
+**CSRF and headers:**
+- Are state-changing operations protected against CSRF (Next.js Server Actions have CSRF protection built-in; API routes do not)?
+- Are sensitive API routes checking the `origin` or using tokens?
+
+### Stage 3: Auditor — Compliance and Standards
+
+Check against Hive's specific standards:
+
+**Hive code standards:**
+- All SQL must use parameterized queries — `$1`, `$2` etc., never string interpolation → CRITICAL if violated
+- API routes return `{ ok: boolean, data?: any, error?: string }` — error messages must not leak internals
+- No raw `fetch()` calls to external services without timeout handling
+- Resend/Stripe/Neon calls inside API routes must have `try/catch`
+
+**OWASP Top 10 quick check:**
+- A01 Broken Access Control — covered by Stage 1 auth checks
+- A02 Cryptographic Failures — any custom crypto implementation? Use Node's built-in `crypto` or edge-compatible alternatives
+- A03 Injection — covered by Stage 1
+- A05 Security Misconfiguration — `NEXT_PUBLIC_` leaks, missing auth checks
+- A09 Security Logging Failures — sensitive data in logs
+
+## Output Format
+
+```
+## security-scan Report — Phase [N]: [phase name]
+
+### Stage 1: Red Team — Attack Surface
+
+**CRITICAL Issues:**
+- file:line — [issue description] [type: SQL injection / command injection / hardcoded secret / etc.]
+[or: NONE]
+
+**HIGH Issues:**
+- file:line — [issue description]
+[or: NONE]
+
+**MEDIUM Issues:**
+- file:line — [issue description]
+[or: NONE]
+
+### Stage 2: Blue Team — Defense Check
+
+**Missing defenses:**
+- file:line — [missing defense]
+[or: All defenses present for identified attack surfaces]
+
+### Stage 3: Auditor — Standards Compliance
+
+**Violations:**
+- file:line — [violation]
+[or: COMPLIANT]
+
+---
+Status: PASS | BLOCKED
+Blocking severity: CRITICAL ([count]) | HIGH ([count])
+WARN-only: MEDIUM ([count])
+```
+
+## Gate Behavior
+
+- **PASS**: No CRITICAL or HIGH issues. /do orchestrator proceeds to the commit subagent.
+- **BLOCKED on CRITICAL**: Hardcoded secrets, SQL injection, command injection. These are deploy-blocking. Dispatch a fix subagent immediately. Max 2 fix attempts before escalating to Carlos with the full report.
+- **BLOCKED on HIGH**: Auth gaps, path traversal, XSS, NEXT_PUBLIC_ leaks. Block and fix. Max 2 fix attempts.
+- **MEDIUM and below**: Note in the phase report but do not block the commit.
+
+## Security Fix Guidance (for fix subagent context)
+
+When dispatching a fix subagent after a BLOCKED result, include:
+
+1. The exact file:line of each blocking issue
+2. The attack scenario (what an attacker could do)
+3. The recommended fix pattern:
+   - SQL injection → parameterized queries (`$1`, `$2`)
+   - Hardcoded secret → move to env var, add to `.env.example`
+   - Missing auth → add `const session = await auth(); if (!session) return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });`
+   - Missing try/catch → wrap external calls in try/catch with structured error return
+
+## What This Is NOT
+
+This is not a full penetration test or a comprehensive SAST scan. It is a diff-scoped, automated security gate that catches the most common and highest-impact issues introduced in a given phase. It complements (does not replace) periodic full audits.
+</security-scan>

--- a/.claude/skills/ts-review/SKILL.md
+++ b/.claude/skills/ts-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ts-review
+description: TypeScript + Next.js App Router compliance reviewer for the /do pipeline. Invoked as Phase 3a in /do after verification passes. Not a substitute for ts-guard (which is interactive/ad-hoc) — this is a pipeline gate that runs on the diff of a completed phase before committing. Also invoke when user says '/ts-review' or 'run ts review'.
+---
+
+<ts-review>
+You are a TypeScript and Next.js App Router compliance gate in the /do execution pipeline. You run AFTER the implementation verification subagent passes and BEFORE the commit subagent fires. Your job is to catch type errors and App Router violations in the diff of the current phase — not the entire codebase.
+
+## Scope Constraint
+
+**Only audit files changed in the current phase diff.** Do not flag pre-existing issues in unmodified files. This is a diff-scoped gate, not a full project audit.
+
+## Checks
+
+### 1. TypeScript Errors (BLOCKING)
+
+Run `npx tsc --noEmit 2>&1 | head -60` and report all errors with file:line.
+
+If TypeScript errors exist: **BLOCK**. Do not allow the phase to commit. Return the error list to the /do orchestrator so a fix subagent can be dispatched.
+
+### 2. Edge Runtime Violations (BLOCKING)
+
+Edge runtime files (any file with `export const runtime = "edge"` or `middleware.ts`) cannot import Node.js-only modules.
+
+**Banned imports in edge files:**
+- `node:fs`, `node:path`, `node:os`, `node:child_process`, `node:crypto`, `node:stream`, `node:http`, `node:https`, `node:net`, `node:tls`, `node:dns`, `node:cluster`, `node:worker_threads`
+- Bare string equivalents: `"fs"`, `"path"`, `"os"`, `"child_process"`, `"crypto"`, `"stream"`, `"http"`, `"https"`, `"net"`, `"tls"`
+
+For each violation: `file:line — imports 'X' which is Node.js-only. Remove or move to a non-edge file.`
+
+If edge violations exist: **BLOCK**.
+
+### 3. App Router Violations (BLOCKING)
+
+Check changed files for:
+
+| Pattern | Rule |
+|---------|------|
+| `export` of non-HTTP-verb from `route.ts` | Route files must only export `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`. Shared logic goes in `src/lib/`. |
+| `'use client'` on a page or layout file | Client boundary should be pushed to leaf components. Flag pages/layouts with `'use client'` unless unavoidable. |
+| `<img>` tag | Must use `next/image` for all images. |
+| Raw string interpolation in SQL | All SQL must use `$1`, `$2` parameterized queries, never template literals. This is a security issue — treat as BLOCKING. |
+
+### 4. Missing Error Handling at API Boundaries (WARN)
+
+In API route handlers (`src/app/api/`): any handler that calls Neon, Stripe, Resend, or external HTTP must have a `try/catch` or structured error return. Flag bare `await` calls in API routes with no surrounding error handling.
+
+This is a WARN — note it but do not block.
+
+### 5. console.log Leaks (WARN)
+
+In any `.ts` or `.tsx` file: `console.log(` is production noise. Hive uses `console.warn` for structured logging per MISTAKES.md.
+
+This is a WARN — note it but do not block.
+
+## Output Format
+
+```
+## ts-review Report — Phase [N]: [phase name]
+
+### TypeScript Errors (BLOCKING)
+- file:line — error message
+[or: NONE]
+
+### Edge Runtime Violations (BLOCKING)
+- file:line — issue
+[or: NONE]
+
+### App Router Violations (BLOCKING)
+- file:line — issue
+[or: NONE]
+
+### Missing Error Handling (WARN)
+- file:line — issue
+[or: NONE]
+
+### console.log Leaks (WARN)
+- file:line — issue
+[or: NONE]
+
+---
+Status: PASS | BLOCKED
+Blocking issues: [count] | WARN-only issues: [count]
+```
+
+## Gate Behavior
+
+- **PASS**: No blocking issues. /do orchestrator proceeds to Phase 3b (security-scan).
+- **BLOCKED**: One or more blocking issues. /do orchestrator dispatches a fix subagent with the blocking issue list. Re-run ts-review after fix. Max 2 fix attempts before escalating to Carlos.
+
+## What This Is NOT
+
+This is not `ts-guard` (the interactive ad-hoc skill). This is a pipeline gate — it runs automatically inside `/do` and its output is consumed by the orchestrator, not presented to Carlos directly (unless blocking after 2 fix attempts).
+</ts-review>


### PR DESCRIPTION
## Summary

- **ts-review skill** (`.claude/skills/ts-review/SKILL.md`): Diff-scoped TypeScript + App Router compliance gate, wired as Phase 3a in `/do`. Blocks deploys on TS errors, edge runtime violations, route.ts exports, `<img>` tags, SQL string interpolation.
- **security-scan skill** (`.claude/skills/security-scan/SKILL.md`): Three-stage security gate (Red Team / Blue Team / Auditor), wired as Phase 3b in `/do`. Blocks on CRITICAL/HIGH severity: SQL injection, hardcoded secrets, auth gaps, XSS, path traversal.
- **Context split** (`.claude/context/`): `dev.md` (coding standards + skills ref), `research.md` (venture ops rules), `review.md` (anti-patterns + self-improvement) — carved from CLAUDE.md to reduce per-task context overhead.
- **`/do` pipeline update**: Steps 3a/3b inserted between Verification and Anti-Pattern; old steps renumbered 3→4, 4→5, 5→6; phase reporting format extended with ts-review + security-scan status lines.

## Test plan

- [ ] Open a session and run `/do` on a small task — verify the pipeline runs: Verification → ts-review → security-scan → Anti-Pattern → Quality → Commit
- [ ] Deliberately introduce a TypeScript error; confirm Step 3a blocks before Step 3b runs
- [ ] Deliberately introduce a missing auth check; confirm Step 3b blocks before commit
- [ ] Verify context files load correctly when referenced in skills (dev.md, research.md, review.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)